### PR TITLE
Fix #47

### DIFF
--- a/workshop/exercise-7/README.md
+++ b/workshop/exercise-7/README.md
@@ -22,7 +22,7 @@ When an application microservice connects to another microservice, the communica
 
 * Mutually authenticated and encrypted connection between Envoy proxies;
 
-When Envoys establish a connection, they exchange and validate certificates to confirm that each is indeed connected to a valid and expected peer. The established identities can later be used as basis for policy checks (e.g., access authorization).
+When Envoy proxies establish a connection, they exchange and validate certificates to confirm that each is indeed connected to a valid and expected peer. The established identities can later be used as basis for policy checks (e.g., access authorization).
 
 ## Steps
 

--- a/workshop/exercise-7/README.md
+++ b/workshop/exercise-7/README.md
@@ -2,7 +2,7 @@
 
 ## Mutual Authentication with Transport Layer Security (mTLS)
 
-Istio can secure the communication between microservices without requiring application code changes.
+Istio can secure the communication between microservices without requiring application code changes. Security is provided by authenticating and encrypting communication paths within the cluster. This is becoming a common security and compliance requirement. Delegating communication security to Istio (as opposed to implementing TLS in each microservice), ensures that your application wil be deployed with consistent and manageable security policies.
 
 Istio Auth is an optional part of Istio's control plane components. When enabled, it provides each Envoy sidecar proxy with a strong (cryptographic) identity, in the form of certificates.
 Identity is based on the microservice's role (specifically, the service account it runs under) and is independent of its specific network location, such as cluster or current IP address.
@@ -22,11 +22,11 @@ When an application microservice connects to another microservice, the communica
 
 * Mutually authenticated and encrypted connection between Envoy proxies;
 
-When Envoy's establish a connection, they exchange and validate certificates to confirm that each is indeed connected to a valid and expected peer. The established identities can later be used as basis for policy checks (e.g., access authorization).
+When Envoys establish a connection, they exchange and validate certificates to confirm that each is indeed connected to a valid and expected peer. The established identities can later be used as basis for policy checks (e.g., access authorization).
 
 ## Steps
 
-### Verifying Istio’s mTLS Setup
+### Verify mTLS Setup
 
 Verify the cluster-level CA is running:
 
@@ -46,7 +46,7 @@ istio-ca   1         1         1            1           15h
 kubectl get configmap istio -o yaml -n istio-system | grep authPolicy | head -1
 ```
 
-Istio mutual TLS authentication is enabled if the line `authPolicy: MUTUAL_TLS` isn't commented (i.e., doesn’t have a leading `#`).
+Istio mutual TLS authentication is enabled if the line `authPolicy: MUTUAL_TLS` isn't commented (i.e., doesn’t have a leading `#`). By default, mutual TLS authentication is enabled. However, if it is disabled/commented, you can [edit the configuration to enable it](#disabling-authentication)
 
 ### Trying out the Authenticated Connection
 
@@ -64,7 +64,7 @@ guestbook-v2-784546fbb9-lcxdz   2/2       Running   0          13h
 
 Make sure the pod is “Running”.
 
-1. ssh into the envoy container
+2. ssh into the envoy container
 
 ```sh
 kubectl exec -it guestbook-v2-xxxxxxxx -c istio-proxy /bin/bash
@@ -72,7 +72,7 @@ kubectl exec -it guestbook-v2-xxxxxxxx -c istio-proxy /bin/bash
 
 Make sure to change the pod name into the corresponding one on your system. This command will ssh into istio-proxy container (sidecar) of the pod.
 
-1. check out the certificate and keys are present
+3. check out the certificate and keys are present
 
 ```sh
 ls /etc/certs/
@@ -86,7 +86,7 @@ cert-chain.pem   key.pem   root-cert.pem
 
 Note that `cert-chain.pem` is Envoy’s public certificate (i.e., presented to the peer), and `key.pem` is the corresponding private key. The `root-cert.pem` file is Istio Auth's root certificate, used to verify peers` certificates.
 
-### Disabling Authentication when Things Go Astray
+### Disabling Authentication
 
 If, for some reason, mTLS is not functional, the Guestbook application will not operate correctly. This would be evident in its UI (e.g., it would display a [`Waiting for database connection`](waiting_on_database.png) message). In that case, mTLS should be disabled.
 


### PR DESCRIPTION
- add motiviation for use
- clarify how to uncomment mutual TLS (links to later section since it is ENABLED by default)
- fix numbering
- remove "go astray"