### PR TITLE
clarified mTLS can't be used between Istio and non-Istio services.

### DIFF
--- a/workshop/README.md
+++ b/workshop/README.md
@@ -1,5 +1,5 @@
 # Beyond the Basics: Istio and IBM Cloud Container Service 
-[Istio](https://www.ibm.com/cloud/info/istio) is an open platform to connect, secure, and manage a network of microservices, also known as a service mesh, on cloud platforms such as Kubernetes in IBM Cloud Container Service. With Istio, manage network traffic, load balance across microservices, enforce access policies, verify service identity on the service mesh, and more.
+[Istio](https://www.ibm.com/cloud/info/istio) is an open platform to connect, secure, and manage a network of microservices, also known as a service mesh, on cloud platforms such as Kubernetes in IBM Cloud Container Service. With Istio, You can manage network traffic, load balance across microservices, enforce access policies, verify service identity on the service mesh, and more.
 
 In this course, you can see how to install Istio alongside microservices for a simple mock app called Guestbook. When you deploy Guestbook's microservices into an IBM Cloud Container Service cluster where Istio is installed, you inject the Istio Envoy sidecar proxies in the pods of each microservice.
 
@@ -17,7 +17,10 @@ After you complete this course, you'll be able to:
 
 ## Prerequisites
 You must you must have a Trial, Pay-As-You-Go, or Subscription [IBM Cloud account](https://console.bluemix.net/registration/) to complete all the modules in this course.
-Note that Kubernetes 1.9.x or newer is recommended, earlier versions may require changes in manifests.
+
+Use Kubernetes 1.9.x or newer because earlier versions may require changes in manifests.
+
+You must have [already created a cluster](https://console.bluemix.net/docs/containers/container_index.html#container_index) in IBM Cloud Container Service. 
 
 You should have a basic understanding of containers, IBM Cloud Container Service, and Istio. If you have no experience with those, take the following courses:
 1. [Get started with Kubernetes and IBM Cloud Container Service](https://developer.ibm.com/courses/all/get-started-kubernetes-ibm-cloud-container-service/)
@@ -26,13 +29,13 @@ You should have a basic understanding of containers, IBM Cloud Container Service
 
 ## Workshop setup
 - [Exercise 1 - Accessing a Kubernetes cluster with IBM Cloud Container Service](exercise-1/README.md)
-
-## Creating a Service Mesh with Istio
-
 - [Exercise 2 - Installing Istio](exercise-2/README.md)
-- [Exercise 3 - Deploy Guestbook with Istio Proxy](exercise-3/README.md)
-- [Exercise 4 - Istio Ingress controller](exercise-4/README.md)
-- [Exercise 5 - Telemetry](exercise-5/README.md)
-- [Exercise 6 - Traffic Management](exercise-6/README.md)
-- [Exercise 7 - Security](exercise-7/README.md)
-- [Exercise 8 - Policy Enforcement](exercise-8/README.md)
+- [Exercise 3 - Deploying Guestbook with Istio Proxy](exercise-3/README.md)
+
+## Creating a service mesh with Istio
+
+- [Exercise 4 - Expose the service mesh with the Istio Ingress controller](exercise-4/README.md)
+- [Exercise 5 - Observe service telemetry: metrics and tracing](exercise-5/README.md)
+- [Exercise 6 - Perform traffic management](exercise-6/README.md)
+- [Exercise 7 - Secure your service mesh](exercise-7/README.md)
+- [Exercise 8 - Enforce policies for microservices](exercise-8/README.md)

--- a/workshop/exercise-1/README.md
+++ b/workshop/exercise-1/README.md
@@ -1,6 +1,6 @@
 # Exercise 1 - Accessing a Kubernetes cluster with IBM Cloud Container Service
 
-Assume you already have a cluster that runs Kubernetes version 1.9 or later. Here are the steps to access your cluster.
+You must already have a [cluster created](https://console.bluemix.net/docs/containers/container_index.html#container_index). Here are the steps to access your cluster.
 
 ## Install IBM Cloud Container Service command line utilities
 

--- a/workshop/exercise-2/README.md
+++ b/workshop/exercise-2/README.md
@@ -14,7 +14,7 @@ export PATH=$PWD/istio-<version-number>/bin:$PATH
 
 5. Install Istio on the Kubernetes cluster. Istio is deployed in the Kubernetes namespace `istio-system`. Since in a later exercise we will try out the mutual TLS features, we install the `istio-auth.yaml` here.
 ```bash
-kubectl apply -f install/kubernetes/istio-auth.yaml
+kubectl apply -f install/kubernetes/istio.yaml
 ```
 
 6. Ensure that the Kubernetes services `istio-ingress`, `istio-mixer`, and `istio-pilot` are fully deployed before you continue.
@@ -27,7 +27,7 @@ istio-ingress   LoadBalancer   172.21.xxx.xxx   169.xx.xxx.xxx   80:31176/TCP,44
 istio-mixer     ClusterIP      172.21.xxx.xxx   <none>           9091/TCP,15004/TCP,9093/TCP,9094/TCP,9102/TCP,9125/UDP,42422/TCP   2m
 istio-pilot     ClusterIP      172.21.xxx.xxx   <none>           15003/TCP,443/TCP                                                  2m
 ```
-7. Ensure the corresponding pods `istio-ca-*`, `istio-ingress-*`, `istio-mixer-*`, and `istio-pilot-*` are also fully deployed before you continue.
+7. Ensure the corresponding pods `istio-ca-*`, `istio-ingress-*`, `istio-mixer-*`, and `istio-pilot-*` are all in **`Running`** state before you continue.
 ```
 kubectl get pods -n istio-system
 ```

--- a/workshop/exercise-3/README.md
+++ b/workshop/exercise-3/README.md
@@ -1,9 +1,9 @@
-# Exercise 3 - Deploy guestbook with Istio Proxy
+# Exercise 3 - Deploy the Guestbook app with Istio Proxy
 
-The Guestbook application is a sample application for users to leave comments. It consists of a web front end, Redis master for storage, and replicated set of Redis slaves. We will also integrate the application with Watson tone analyzer service that detects the sentiment in user's comments and reply with emoticons. Here are the steps to deploy the application on your Kubernets cluster:
+The Guestbook app is a sample app for users to leave comments. It consists of a web front end, Redis master for storage, and replicated set of Redis slaves. We will also integrate the app with Watson Tone Analyzer that detects the sentiment in user's comments and replies with emoticons. Here are the steps to deploy the app on your Kubernetes cluster:
 
-### Download the guestbook app
-1. Open your preferred terminal and download the guestbook app from GitHub.
+### Download the Guestbook app
+1. Open your preferred terminal and download the Guestbook app from GitHub.
   ```sh
   git clone https://github.com/IBM/guestbook.git
   ```
@@ -46,24 +46,23 @@ The Redis database is a service that you can use to persist the data of your app
   ```
 ## Sidecar injection
 
-In Kubernets, a sidecar is a utility container in the Pod and its purpose is to support the main container. For Istio to work, Envoy proxies must be deployed as sidecars to each pod of the deployment. There are two ways of injecting the Istio sidecar into a pod: manually using istioctl CLI tool or automatically using the Istio Initializer. In this exercise, we will use the manual injection. Manual injection modifies the controller configuration, e.g. deployment. It does this by modifying the pod template spec such that all pods for that deployment are created with the injected sidecar. 
+In Kubernetes, a sidecar is a utility container in the pod, and its purpose is to support the main container. For Istio to work, Envoy proxies must be deployed as sidecars to each pod of the deployment. There are two ways of injecting the Istio sidecar into a pod: manually using istioctl CLI tool or automatically using the Istio Initializer. In this exercise, we will use the manual injection. Manual injection modifies the controller configuration, e.g. deployment. It does this by modifying the pod template spec such that all pods for that deployment are created with the injected sidecar. 
 
-## Install the guestbook app with Manual sidecar injection
+## Install the Guestbook app with manual sidecar injection
 
   ```sh
  kubectl apply -f <(istioctl kube-inject -f ../v1/guestbook-deployment.yaml --debug)
  kubectl apply -f <(istioctl kube-inject -f guestbook-deployment.yaml --debug)
   ```
-These commands will inject the Istio envoy sidecar into the guestbook pods, as well as deploy the guestbook app on to the K8s cluster. Here we have two versions of deployments, a new version (`v2`) in the current directory, and a previous version (`v1`) in a sibling directory. They will be used in future sections to showcase the Istio traffic routing capabilities.
+These commands will inject the Istio Envoy sidecar into the guestbook pods, as well as deploy the Guestbook app on to the Kubernetes cluster. Here we have two versions of deployments, a new version (`v2`) in the current directory, and a previous version (`v1`) in a sibling directory. They will be used in future sections to showcase the Istio traffic routing capabilities.
   
 Next, we'll create the guestbook service.
 
-1. Inject the Istio envoy sidecar into the guestbook pods and deploy the guestbook app on to the Kubernetes cluster.
+1. Inject the Istio Envoy sidecar into the guestbook pods, and deploy the Guestbook app on to the Kubernetes cluster.
 ```sh
 kubectl apply -f <(istioctl kube-inject -f ../v1/guestbook-deployment.yaml --debug)
 kubectl apply -f <(istioctl kube-inject -f guestbook-deployment.yaml --debug)
 ```
-These commands create two versions of deployments: a new version (`v2`) in the current directory, and a previous version (`v1`) in a sibling directory. They will be used in future exercises to showcase the Istio traffic routing capabilities.
 
 2. Create the guestbook service.
 ```sh
@@ -89,45 +88,42 @@ guestbook-v2-56d98b558c-dshkh   2/2       Running   0          5d
 guestbook-v2-56d98b558c-mzbxk   2/2       Running   0          5d
 ```
 
-Note that each guestbook pod has 2 containers in it. One is the guestbook container, and the other is the envoy proxy sidecar.
+Note that each guestbook pod has 2 containers in it. One is the guestbook container, and the other is the Envoy proxy sidecar.
 
-### Add the analyzer service
-The Watson Tone analyzer service detects the tone from the words that users enter into the guestbook app. The tone is converted to the corresponding emoticons. 
+### Add Watson Tone Analyzer
+Watson Tone Analyzer detects the tone from the words that users enter into the Guestbook app. The tone is converted to the corresponding emoticons. 
 
-Before you begin: 
-- Use `bx target --cf` or `bx target -o ORG -s SPACE` to set the Cloud Foundry org and space where you want to provision the service. 
+1. Use `bx target --cf` or `bx target -o ORG -s SPACE` to set the Cloud Foundry org and space where you want to provision the service. 
 
-    > Note that you should use `bx target --cf` or `bx target -o ORG -s SPACE` to set the Cloud Foundry Org and Space before calling `bx service create...`. 
-
-   1. Create the Watson Tone analyzer service in your space. 
+2. Create Watson Tone Analyzer in your space. 
       ```console
       bx service create tone_analyzer lite my-tone-analyzer-service
       ```
       
-   2. Create a service key for the service. 
+3. Create a service key for the service. 
       ```console
       bx service key-create my-tone-analyzer-service myKey
       ```
    
-   3. Show the service key that you created and note the **password** and **username**. 
+4. Show the service key that you created and note the **password** and **username**. 
       ```console
       bx service key-show my-tone-analyzer-service myKey
       ```
 
-2. Open the `analyzer-deployment.yaml` and delete the `#` from the `env var` section to un-comment the username and password fields.
+5. Open the `analyzer-deployment.yaml` and delete the `#` from the `env var` section to un-comment the username and password fields.
 
-3. Add the username and password that you retrieved earlier and save your changes.
+6. Add the username and password that you retrieved earlier and save your changes.
 
-4. Deploy the analyzer pods and service. The analyzer service talks to the Watson Tone analyzer to help analyze the tone of a message.
+7. Deploy the analyzer pods and service. The analyzer service talks to Watson Tone Analyzer to help analyze the tone of a message.
    ```console
    kubectl apply -f analyzer-deployment.yaml --debug
    kubectl apply -f analyzer-service.yaml
    ```
    
-5. Create an egress rule to allow the analyzer service to access the Watson service. The rule is defined in [istio101/workshop/plans](https://github.com/IBM/istio101/tree/master/workshop/plans) and is not part of the guestbook app files:
+5. Create an egress rule to allow the analyzer service to access Watson Tone Analyzer. The rule is defined in [istio101/workshop/plans](https://github.com/IBM/istio101/tree/master/workshop/plans) and is not part of the Guestbook app files:
     ```console
       kubectl apply -f analyzer-egress.yaml
     ```
-Great! With you guestbook up and running, you can now expose the service mesh with the Istio Ingress controller. 
+Great! With you Guestbook up and running, you can now expose the service mesh with the Istio Ingress controller. 
 
 #### [Continue to Exercise 4 - Expose the service mesh with the Istio Ingress controller](../exercise-4/README.md)

--- a/workshop/exercise-4/README.md
+++ b/workshop/exercise-4/README.md
@@ -4,7 +4,7 @@ The components deployed on the service mesh by default are not exposed outside t
 
 A Kubernetes Ingress rule can be created that routes external requests through the Istio Ingress controller to the backing services. In a Kubernetes environment, Istio uses Kubernetes Ingress Resources to configure ingress behavior.
 
-### Expose the guestbook app with Ingress
+### Expose the Guestbook app with Ingress
 
 1. Configure the guestbook default route with the Istio Ingress controller.
 
@@ -40,7 +40,7 @@ A Kubernetes Ingress rule can be created that routes external requests through t
     istio-ingress   LoadBalancer   172.21.126.221   169.61.37.141   80:31432/TCP,443:31753/TCP   3h
     ```
     
-3. Access the guestbook app by using the external IP address that you retrieved in the previous step. 
+3. Access the Guestbook app by using the external IP address that you retrieved in the previous step. 
    Example: 
    ```
    http://169.61.37.141
@@ -52,7 +52,7 @@ Now you can access the guestbook via http://<EXTERNAL_IP>. The above example IP 
 
 **Note:** This task requires a standard cluster. 
 
-To have an IBM-provided DNS for the guestbook app, you must set up the Istio Ingress controller to route traffic to the Kubernetes Ingress application load balancer (ALB). 
+To have an IBM-provided DNS for the Guestbook app, you must set up the Istio Ingress controller to route traffic to the Kubernetes Ingress application load balancer (ALB). 
 
 The IBM Ingress service provides IBM Cloud users with a secure, reliable, and scalable network stack to distribute incoming network traffic to apps in IBM Cloud. You can enhance the IBM-provided Ingress application load balancer by adding annotions. Learn more about [Ingress for IBM Cloud Container Service](https://console.bluemix.net/docs/containers/cs_ingress.html#ingress). 
 
@@ -94,7 +94,7 @@ Ingress subdomain:	guestbook-242887.us-east.containers.mybluemix.net
                  servicePort: 3000
    ```
    
-5. Use the IBM-provided subdomain to access your guestbook app. 
+5. Use the IBM-provided subdomain to access your Guestbook app. 
    Example: 
    ```
    http://[guestbook].us-east.containers.mybluemix.net

--- a/workshop/exercise-5/README.md
+++ b/workshop/exercise-5/README.md
@@ -1,8 +1,8 @@
-# Exercise 5 - Telemetry
+# Exercise 5 - Observe service telemetry: metrics and tracing
 
 ### Challenges with microservices
 
-For the longest time in the history of application development, applications were built with monolith mindset. Monolith applications have a large number of instances running all of the services provided in one application. Things like user account management, payment, and reporting are all run from a shared resource. This worked pretty well until service-oriented architecture (SOA) came along and promised us a much brighter future. The basic principle of SOA is to break down applications to smaller components, and having them to talk to one other using protocols like REST or gRPC. Everyone thought this would fundamentally change the landscape, and it did--up to an extent. However, a new set of challenges emerged. What about cross-services communication? What about observability between microservices, such as logging or tracing? What about metrics?
+For the longest time in the history of app development, apps were built with monolith mindset. Monolith apps have a large number of instances running all of the services provided in one app. Things like user account management, payment, and reporting are all run from a shared resource. This worked pretty well until service-oriented architecture (SOA) came along and promised us a much brighter future. The basic principle of SOA is to break down apps to smaller components, and having them to talk to one other using protocols like REST or gRPC. Everyone thought this would fundamentally change the landscape, and it did--up to an extent. However, a new set of challenges emerged. What about cross-services communication? What about observability between microservices, such as logging or tracing? What about metrics?
 
 ### Istio telemetry
 
@@ -42,7 +42,7 @@ You can read more about how [Istio mixer enables telemetry reporting](https://is
       ```sh
       istioctl create -f guestbook-telemetry.yaml
       ```
-   3. Generate a small load to the application.
+   3. Generate a small load to the app.
       ```sh
       while sleep 0.5; do curl http://<guestbook_loadbalancer_external_IP/; done
       ```
@@ -105,7 +105,7 @@ kubectl -n istio-system logs $(kubectl -n istio-system get pods -l istio=mixer -
 
 Although Istio proxies are able to automatically send spans, they need some hints to tie together the entire trace. Apps need to propagate the appropriate HTTP headers so that when the proxies send span information to Zipkin or Jaeger, the spans can be correlated correctly into a single trace.
 
-In the example, when a user visits the guestbook, the HTTP request is sent from the guestbook service to the Watson Tone analyzer service. In order for the individual spans of guestbook service and analyzer service to be tied together, we have modified the guestbook service to extract the required headers (x-request-id, x-b3-traceid, x-b3-spanid, x-b3-parentspanid, x-b3-sampled, x-b3-flags, x-ot-span-context) and forward them onto the analyzer service when calling the analyzer service from the guestbook service.  The change is in the `v2/guestbook/main.go`. By using the `getForwardHeaders()` method, we are able to extract the required headers, and then we use the required headers further when calling the analyzer service via the `getPrimaryTone()` method.
+In the example, when a user visits the Guestbook app, the HTTP request is sent from the guestbook service to Watson Tone Analyzer. In order for the individual spans of guestbook service and Watson Tone Analyzer to be tied together, we have modified the guestbook service to extract the required headers (x-request-id, x-b3-traceid, x-b3-spanid, x-b3-parentspanid, x-b3-sampled, x-b3-flags, x-ot-span-context) and forward them onto the analyzer service when calling the analyzer service from the guestbook service.  The change is in the `v2/guestbook/main.go`. By using the `getForwardHeaders()` method, we are able to extract the required headers, and then we use the required headers further when calling the analyzer service via the `getPrimaryTone()` method.
 
 
 ## Quizzes

--- a/workshop/exercise-6/README.md
+++ b/workshop/exercise-6/README.md
@@ -1,7 +1,7 @@
-# Exercise 6 - Traffic Management
+# Exercise 6 - Perform traffic management
 
-## Using Rules to Manage Traffic
-The core component used for traffic management in Istio is Pilot, which manages and configures all the Envoy proxy instances deployed in a particular Istio service mesh. It lets you specify what rules you want to use to route traffic between Envoy proxies, which run as sidecars to each service in the mesh.  Each service consists of any number of instances running on pods, containers, VMs etc.  Each service can have any number of versions (a.k.a. subsets).  There can be distinct subsets of service instances running different variants of the application binary. These variants are not necessarily different API versions. They could be iterative changes to the same service, deployed in different environments (prod, staging, dev, etc.).  Pilot translates high-level rules into low-level configurations and distributes this config to Envoy instances.  Pilot uses three types of configuration resources to manage traffic within its service mesh: Virtual Services, Destination Rules, and Service Entries.
+## Using rules to manage traffic
+The core component used for traffic management in Istio is Pilot, which manages and configures all the Envoy proxy instances deployed in a particular Istio service mesh. It lets you specify what rules you want to use to route traffic between Envoy proxies, which run as sidecars to each service in the mesh.  Each service consists of any number of instances running on pods, containers, VMs etc.  Each service can have any number of versions (a.k.a. subsets).  There can be distinct subsets of service instances running different variants of the app binary. These variants are not necessarily different API versions. They could be iterative changes to the same service, deployed in different environments (prod, staging, dev, etc.).  Pilot translates high-level rules into low-level configurations and distributes this config to Envoy instances.  Pilot uses three types of configuration resources to manage traffic within its service mesh: Virtual Services, Destination Rules, and Service Entries.
 
 ### Virtual Services
 A [VirtualService](https://istio.io/docs/reference/config/istio.networking.v1alpha3.html#VirtualService) defines a set of traffic routing rules to apply when a host is addressed. Each routing rule defines matching criteria for traffic of a specific protocol. If the traffic is matched, then it is sent to a named [destination](https://istio.io/docs/reference/config/istio.networking.v1alpha3.html#Destination) service (or [subset](https://istio.io/docs/reference/config/istio.networking.v1alpha3.html#Subset) or version of it) defined in the service registry.
@@ -12,11 +12,11 @@ A [DestinationRule](https://istio.io/docs/reference/config/istio.networking.v1al
 ### Service Entries
 A [ServiceEntry](https://istio.io/docs/reference/config/istio.networking.v1alpha3.html#ServiceEntry) configuration enables services within the mesh to access a service not necessarily managed by Istio.  The rule describes the endpoints, ports and protocols of a white-listed set of mesh-external domains and IP blocks that services in the mesh are allowed to access.
 
-## The Guestbook Example
-In the Guestbook example, there is one service: guestbook.  The guestbook service has two distinct versions: the base version (version 1) and the modernized version (version 2).  Each version of the service has three instances based on the number of replicas in [guestbook-deployment.yaml](https://github.com/linsun/examples/blob/master/guestbook-go/guestbook-deployment.yaml) and [guestbook-v2-deployment.yaml](https://github.com/linsun/examples/blob/master/guestbook-go/guestbook-v2-deployment.yaml).  By default, prior to creating any rules, Istio will route requests equally across version 1 and version 2 of the guestbook service and their respective instances in a round robin manner.  However, new versions of a service can easily introduce bugs to the service mesh, so following A/B Testing and Canary Deployments are recommended practices to follow.
+## The Guestbook app
+In the Guestbook app, there is one service: guestbook.  The guestbook service has two distinct versions: the base version (version 1) and the modernized version (version 2).  Each version of the service has three instances based on the number of replicas in [guestbook-deployment.yaml](https://github.com/linsun/examples/blob/master/guestbook-go/guestbook-deployment.yaml) and [guestbook-v2-deployment.yaml](https://github.com/linsun/examples/blob/master/guestbook-go/guestbook-v2-deployment.yaml).  By default, prior to creating any rules, Istio will route requests equally across version 1 and version 2 of the guestbook service and their respective instances in a round robin manner.  However, new versions of a service can easily introduce bugs to the service mesh, so following A/B Testing and Canary Deployments is good practice.
 
-### A/B Testing with Istio
-A/B testing is a method of performing identical tests against two separate service versions in order to determine which performs better.  To prevent Istio from performing the default routing behavior between the original and modernized guestbook service, the following rules should be defined:
+### A/B testing with Istio
+A/B testing is a method of performing identical tests against two separate service versions in order to determine which performs better.  To prevent Istio from performing the default routing behavior between the original and modernized guestbook service, define the following rules:
 
 ```yaml
 apiVersion: networking.istio.io/v1alpha3
@@ -51,7 +51,7 @@ spec:
 
 The `VirtualService` defines a rule that captures all HTTP traffic going to hostname `guestbook` and routes 100% of the traffic to pods of the guestbook service with label "version: v1".  A subset or version of a route destination is identified with a reference to a named service subset which must be declared in a corresponding `DestinationRule`.  Since there are three instances matching the criteria of hostname `guestbook` and subset `version: v1`, by default Envoy will send traffic to all three instances in a round robin manner.
 
-To enable the Istio service mesh for A/B testing against the new service version, the original `VirtualService` rule can be modified to the following:
+To enable the Istio service mesh for A/B testing against the new service version, modify the original `VirtualService` rule:
 
 ```yaml
 apiVersion: networking.istio.io/v1alpha3
@@ -78,8 +78,8 @@ spec:
 
 In Istio `VirtualService` rules, there can be only one rule for each service and therefore when defining multiple [HTTPRoute](https://istio.io/docs/reference/config/istio.networking.v1alpha3.html#HTTPRoute) blocks, the order in which they are defined in the yaml matters.  With the modified rule, incoming requests going to hostname `guestbook` that contain a header `istio-test-header` with value `version2` will go to the newer version of guestbook.  All other requests fall-through to the next block, which routes all traffic to the original version of guestbook.  This way the same performance tests and functionality tests can be used to run against version 1 and version 2 just by appending a header.
 
-### Canary Deployment
-In `Canary Deployments`, newer versions of services are incrementally rolled out to users to minimize the risk and impact of any bugs introduced by the newer version.  To begin incrementally routing traffic to the newer version of the guestbook service, the original `VirtualService` rule can be modified to the following:
+### Canary deployment
+In `Canary Deployments`, newer versions of services are incrementally rolled out to users to minimize the risk and impact of any bugs introduced by the newer version.  To begin incrementally routing traffic to the newer version of the guestbook service, modify the original `VirtualService` rule:
 
 ```yaml
 apiVersion: networking.istio.io/v1alpha3
@@ -103,12 +103,12 @@ spec:
 
 In the modified rule, the routed traffic is split between two different subsets of the guestbook service.  In this manner, traffic to the modernized version 2 of guestbook is controlled on a percentage basis to limit the impact of any unforeseen bugs.  This rule can be modified over time until eventually all traffic is directed to the newer version of the service.
 
-### Implementing Circuit Breakers with Destination Rules
-Istio `DestinationRules` allow users to configure Envoy's implementation of [circuit breakers](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/circuit_breaking).  Circuit breakers are critical for defining the behavior for service-to-service communication in the service mesh.  In the event of a failure for a particular service, circuit breakers allow users to set global defaults for failure recovery on a per service and/or per service version basis.  Users can apply a [traffic policy](https://istio.io/docs/reference/config/istio.networking.v1alpha3.html#TrafficPolicy) at the top level of the `DestinationRule` to create circuit breaker settings for an entire service or it can be defined at the subset level to create settings for a particular version of a service.
+### Implementing circuit breakers with destination rules
+Istio `DestinationRules` allow users to configure Envoy's implementation of [circuit breakers](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/circuit_breaking).  Circuit breakers are critical for defining the behavior for service-to-service communication in the service mesh.  In the event of a failure for a particular service, circuit breakers allow users to set global defaults for failure recovery on a per service and/or per service version basis.  Users can apply a [traffic policy](https://istio.io/docs/reference/config/istio.networking.v1alpha3.html#TrafficPolicy) at the top level of the `DestinationRule` to create circuit breaker settings for an entire service, or it can be defined at the subset level to create settings for a particular version of a service.
 
 Depending on whether a service handles [HTTP](https://istio.io/docs/reference/config/istio.networking.v1alpha3.html#ConnectionPoolSettings.HTTPSettings) requests or [TCP](https://istio.io/docs/reference/config/istio.networking.v1alpha3.html#ConnectionPoolSettings.TCPSettings) connections, `DestinationRules` expose a number of ways for Envoy to limit traffic to a particular service as well as define failure recovery behavior for services initiating the connection to an unhealthy service.
 
-## Further Reading
+## Further reading
 * [Istio Concept](https://istio.io/docs/concepts/traffic-management/)
 * [Istio Rules API](https://istio.io/docs/reference/config/istio.networking.v1alpha3.html)
 * [Istio V1alpha1 to V1alpha3 Converter Tool](https://istio.io/docs/reference/commands/istioctl.html#istioctl%20experimental%20convert-networking-config)

--- a/workshop/exercise-7/README.md
+++ b/workshop/exercise-7/README.md
@@ -37,6 +37,7 @@ If you have previously deployed Istio without cluster-level CA, start by redeplo
 kubectl delete -f install/kubernetes/istio.yaml
 kubectl apply -f install/kubernetes/istio-auth.yaml
 ```
+
 Be sure to confirm that Istio is running before continuing. See [exercise-2](../exercise-2/README.md) for more details.
 
 Verify the cluster-level CA is running:

--- a/workshop/exercise-7/README.md
+++ b/workshop/exercise-7/README.md
@@ -26,6 +26,7 @@ When Envoy proxies establish a connection, they exchange and validate certificat
 
 ## Steps
 
+<<<<<<< HEAD
 > Version 2 of the guestbook application uses an external service (tone analyzer) which is not Istio-enabled. Current Istio release (0.8) has a [known limitation](https://istio.io/help/faq/security.html#istio-to-not-istio), where where an mTLS enabled service fails to communicate with a service without Istio. This limitation will be lifted in an upcoming release.
 > Thus, we will disable mTLS globally and enable it only for communication between internal cluster services in this lab.
 
@@ -39,6 +40,12 @@ kubectl apply -f install/kubernetes/istio-auth.yaml
 ```
 
 Be sure to confirm that Istio is running before continuing. See [exercise-2](../exercise-2/README.md) for more details.
+=======
+> Version 2 of the guestbook application uses an external service (tone analyzer) that is not Istio enabled. The current Istio release (0.8) has a [known limitation](https://istio.io/help/faq/security.html#istio-to-not-istio) where where an mTLS enabled service fails to communicate with a service without Istio. This limitation will be lifted in an upcoming release.
+> Thus, we will disable mTLS globally and enable it only for communication between internal cluster services in this lab.
+
+### Verify mTLS Setup
+>>>>>>> 03a22d0d0f73728c237292a3a5061864fc6995fa
 
 Verify the cluster-level CA is running:
 
@@ -116,6 +123,7 @@ data:
 
 kubectl delete pod istio-pilot-657cb5ddf7-9c6nv -n istio-system
 pod "istio-pilot-657cb5ddf7-9c6nv" deleted
+<<<<<<< HEAD
 ```
 
 After Istio Pilot is restarted, the Guestbook user interface should display correctly.
@@ -137,6 +145,29 @@ spec:
   ...
 ```
 
+=======
+```
+
+After Istio Pilot is restarted, the Guestbook user interface should display correctly.
+
+* We can now gradually enable mTLS on individual services. For example, in the case of Guestbook we can enable mTLS for the guestbook service:
+
+```sh
+kubectl edit service guestbook
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    auth.istio.io/3000: MUTUAL_TLS
+  ...
+spec:
+  ports:
+    - name: http
+      targetPort: 3000
+  ...
+```
+
+>>>>>>> 03a22d0d0f73728c237292a3a5061864fc6995fa
 * Note that annotations also be used to disable mTLS for connections accessing a specific service. Since mTLS is triggered by the server-side proxy requesting a client certificate, add an `auth.istio.io/<port#>: NONE` annotation to the service definition. For example, to disable mTLS on guestbook and analyzer:
 
 ```sh

--- a/workshop/exercise-7/README.md
+++ b/workshop/exercise-7/README.md
@@ -1,8 +1,8 @@
-# Exercise 7 - Security
+# Exercise 7 - Secure your services
 
-## Mutual Authentication with Transport Layer Security (mTLS)
+## Mutual authentication with Transport Layer Security (mTLS)
 
-Istio can secure the communication between microservices without requiring application code changes. Security is provided by authenticating and encrypting communication paths within the cluster. This is becoming a common security and compliance requirement. Delegating communication security to Istio (as opposed to implementing TLS in each microservice), ensures that your application wil be deployed with consistent and manageable security policies.
+Istio can secure the communication between microservices without requiring app code changes. Security is provided by authenticating and encrypting communication paths within the cluster. This is becoming a common security and compliance requirement. Delegating communication security to Istio (as opposed to implementing TLS in each microservice), ensures that your app will be deployed with consistent and manageable security policies.
 
 Istio Auth is an optional part of Istio's control plane components. When enabled, it provides each Envoy sidecar proxy with a strong (cryptographic) identity, in the form of certificates.
 Identity is based on the microservice's the service account and is independent of its specific network location, such as cluster or current IP address.
@@ -16,19 +16,15 @@ Istio Auth is responsible for:
 
 * Providing a key management system, automating generation, distribution, and rotation of certificates and keys.
 
-When an application microservice connects to another microservice, the communication is tunneled through the client side and server side Envoys. The end-to-end communication flow is:
+When an app microservice connects to another microservice, the communication is tunneled through the client side and server side Envoys. The end-to-end communication flow is:
 
-* Local TCP connection (i.e., `localhost`, not reaching the "wire") between the application and Envoy (client- and server-side);
+* Local TCP connection (i.e., `localhost`, not reaching the "wire") between the app and Envoy (client- and server-side);
 
 * Mutually authenticated and encrypted connection between Envoy proxies.
 
 When Envoy proxies establish a connection, they exchange and validate certificates to confirm that each is indeed connected to a valid and expected peer. The established identities can later be used as basis for policy checks (e.g., access authorization).
 
-## Steps
-
-### Verify mTLS Setup
-
-Verify the cluster-level CA is running:
+1. Verify the mTLS setup by checking the cluster-level CA:
 
 ```sh
 kubectl get deployment -l istio=istio-ca -n istio-system
@@ -40,17 +36,17 @@ NAME       DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
 istio-ca   1         1         1            1           15h
 ```
 
-### Verify AuthPolicy Setting in ConfigMap
+2. Verify the AuthPolicy setting in ConfigMap:
 
 ```sh
 kubectl get configmap istio -o yaml -n istio-system | grep authPolicy | head -1
 ```
 
-Istio mutual TLS authentication is enabled if the line `authPolicy: MUTUAL_TLS` isn't commented (i.e., doesn’t have a leading `#`). By default, mutual TLS authentication is enabled. However, if it is disabled/commented, you can [edit the configuration to enable it](#disabling-authentication)
+Istio mutual TLS authentication is enabled if the line `authPolicy: MUTUAL_TLS` isn't commented (i.e., doesn’t have a leading `#`). By default, mutual TLS authentication is enabled. However, if it is disabled/commented, you can [edit the configuration to enable it](#disabling-authentication).
 
-### Trying out the Authenticated Connection
+## Trying out the authenticated connection
 
-If mTLS is working correctly, the Guestbook application should continue to operate as expected, without any user visible impact. Istio will automatically add (and manage) the required certificates and private keys. To confirm their presence in the Envoy containers, do the following:
+If mTLS is working correctly, the Guestbook app should continue to operate as expected, without any user visible impact. Istio will automatically add (and manage) the required certificates and private keys. To confirm their presence in the Envoy containers, do the following:
 
 1. Get the name of a guestbook-v2 pod. Make sure the pod is “Running”.
 
@@ -62,7 +58,7 @@ guestbook-v2-784546fbb9-hsbnq   2/2       Running   0          13h
 guestbook-v2-784546fbb9-lcxdz   2/2       Running   0          13h
 ```
 
-2. SSH into the envoy container. Make sure to change the pod name into the corresponding one on your system. This command will ssh into istio-proxy container (sidecar) of the pod.
+2. SSH into the Envoy container. Make sure to change the pod name into the corresponding one on your system. This command will ssh into istio-proxy container (sidecar) of the pod.
 
 ```sh
 kubectl exec -it guestbook-v2-xxxxxxxx -c istio-proxy /bin/bash
@@ -80,13 +76,13 @@ You should see the following (plus some others):
 cert-chain.pem   key.pem   root-cert.pem
 ```
 
-Note that `cert-chain.pem` is Envoy’s public certificate (i.e., presented to the peer), and `key.pem` is the corresponding private key. The `root-cert.pem` file is Istio Auth's root certificate, used to verify peers` certificates.
+Note that `cert-chain.pem` is Envoy’s public certificate (i.e., presented to the peer), and `key.pem` is the corresponding private key. The `root-cert.pem` file is Istio Auth's root certificate, used to verify peer certificates.
 
-### Disabling Authentication
+## Disabling authentication
 
-If, for some reason, mTLS is not functional, the Guestbook application will not operate correctly. This would be evident in its UI (e.g., it would display a [`Waiting for database connection`](waiting_on_database.png) message). In that case, mTLS should be disabled.
+If, for some reason, mTLS is not functional, the Guestbook app will not operate correctly. This would be evident in its UI (e.g., it would display a [`Waiting for database connection`](waiting_on_database.png) message). In that case, mTLS should be disabled.
 
-mTLS it can be disabled globally or per service.
+mTLS can be disabled globally or per service:
 
 * To disable mTLS for all services in the mesh, comment out the `authPolicy` settings in the mesh configuration:
 
@@ -138,7 +134,7 @@ Note that the annotations can also be used to gradually enable mTLS on individua
 
 1. Istio Auth/Citadel provides each microservice with a strong, cryptographic, identity in the form of a certificate. The certificates' life cycle is fully managed by Istio. (True)
 
-2. Istio provides microservices with mutually authenticated connections, without requiring application code changes. (True)
+2. Istio provides microservices with mutually authenticated connections, without requiring app code changes. (True)
 
 3. Mutual authentication must be on or off for the entire cluster, gradual adoption is not possible. (False)
 

--- a/workshop/exercise-7/README.md
+++ b/workshop/exercise-7/README.md
@@ -26,7 +26,6 @@ When Envoy proxies establish a connection, they exchange and validate certificat
 
 ## Steps
 
-<<<<<<< HEAD
 > Version 2 of the guestbook application uses an external service (tone analyzer) which is not Istio-enabled. Current Istio release (0.8) has a [known limitation](https://istio.io/help/faq/security.html#istio-to-not-istio), where where an mTLS enabled service fails to communicate with a service without Istio. This limitation will be lifted in an upcoming release.
 > Thus, we will disable mTLS globally and enable it only for communication between internal cluster services in this lab.
 
@@ -40,12 +39,6 @@ kubectl apply -f install/kubernetes/istio-auth.yaml
 ```
 
 Be sure to confirm that Istio is running before continuing. See [exercise-2](../exercise-2/README.md) for more details.
-=======
-> Version 2 of the guestbook application uses an external service (tone analyzer) that is not Istio enabled. The current Istio release (0.8) has a [known limitation](https://istio.io/help/faq/security.html#istio-to-not-istio) where where an mTLS enabled service fails to communicate with a service without Istio. This limitation will be lifted in an upcoming release.
-> Thus, we will disable mTLS globally and enable it only for communication between internal cluster services in this lab.
-
-### Verify mTLS Setup
->>>>>>> 03a22d0d0f73728c237292a3a5061864fc6995fa
 
 Verify the cluster-level CA is running:
 
@@ -123,7 +116,6 @@ data:
 
 kubectl delete pod istio-pilot-657cb5ddf7-9c6nv -n istio-system
 pod "istio-pilot-657cb5ddf7-9c6nv" deleted
-<<<<<<< HEAD
 ```
 
 After Istio Pilot is restarted, the Guestbook user interface should display correctly.
@@ -145,29 +137,6 @@ spec:
   ...
 ```
 
-=======
-```
-
-After Istio Pilot is restarted, the Guestbook user interface should display correctly.
-
-* We can now gradually enable mTLS on individual services. For example, in the case of Guestbook we can enable mTLS for the guestbook service:
-
-```sh
-kubectl edit service guestbook
-apiVersion: v1
-kind: Service
-metadata:
-  annotations:
-    auth.istio.io/3000: MUTUAL_TLS
-  ...
-spec:
-  ports:
-    - name: http
-      targetPort: 3000
-  ...
-```
-
->>>>>>> 03a22d0d0f73728c237292a3a5061864fc6995fa
 * Note that annotations also be used to disable mTLS for connections accessing a specific service. Since mTLS is triggered by the server-side proxy requesting a client certificate, add an `auth.istio.io/<port#>: NONE` annotation to the service definition. For example, to disable mTLS on guestbook and analyzer:
 
 ```sh

--- a/workshop/exercise-7/README.md
+++ b/workshop/exercise-7/README.md
@@ -24,7 +24,22 @@ When an app microservice connects to another microservice, the communication is 
 
 When Envoy proxies establish a connection, they exchange and validate certificates to confirm that each is indeed connected to a valid and expected peer. The established identities can later be used as basis for policy checks (e.g., access authorization).
 
-1. Verify the mTLS setup by checking the cluster-level CA:
+## Steps
+
+> Version 2 of the guestbook application uses an external service (tone analyzer) which is not Istio-enabled. Current Istio release (0.8) has a [known limitation](https://istio.io/help/faq/security.html#istio-to-not-istio), where where an mTLS enabled service fails to communicate with a service without Istio. This limitation will be lifted in an upcoming release.
+> Thus, we will disable mTLS globally and enable it only for communication between internal cluster services in this lab.
+
+1. Setting up Istio Certificate Authority (CA)
+
+If you have previously deployed Istio without cluster-level CA, start by redeploying Istio using istio-auth.yaml file:
+
+```sh
+kubectl delete -f install/kubernetes/istio.yaml
+kubectl apply -f install/kubernetes/istio-auth.yaml
+```
+Be sure to confirm that Istio is running before continuing. See [exercise-2](../exercise-2/README.md) for more details.
+
+Verify the cluster-level CA is running:
 
 ```sh
 kubectl get deployment -l istio=istio-ca -n istio-system
@@ -39,10 +54,12 @@ istio-ca   1         1         1            1           15h
 2. Verify the AuthPolicy setting in ConfigMap:
 
 ```sh
-kubectl get configmap istio -o yaml -n istio-system | grep authPolicy | head -1
+kubectl get configmap istio -n istio-system | grep authPolicy | head -1
 ```
 
 Istio mutual TLS authentication is enabled if the line `authPolicy: MUTUAL_TLS` isn't commented (i.e., doesn’t have a leading `#`). By default, mutual TLS authentication is enabled. However, if it is disabled/commented, you can [edit the configuration to enable it](#disabling-authentication).
+
+Due to a [known limitation](https://istio.io/help/faq/security.html#istio-to-not-istio), the Guestbook application can not currently work with mTLS enabled for all services, and it should be disabled globally. Until the limitation is fixed, follow through with the steps defined [here](#disabling-authentication) instead of those listed directly below.
 
 ## Trying out the authenticated connection
 
@@ -84,10 +101,10 @@ If, for some reason, mTLS is not functional, the Guestbook app will not operate 
 
 mTLS can be disabled globally or per service:
 
-* To disable mTLS for all services in the mesh, comment out the `authPolicy` settings in the mesh configuration:
+* To disable mTLS for all services in the mesh, comment out the `authPolicy` settings in the mesh configuration and restart Istio Pilot to pick up the new configuration:
 
 ```sh
-kubectl edit configmap istio -o yaml -n istio-system
+kubectl edit configmap istio -n istio-system
 ...
 apiVersion: v1
 data:
@@ -95,9 +112,31 @@ data:
     # Uncomment the following line to enable mutual TLS between proxies
     # authPolicy: MUTUAL_TLS
     ...
+
+kubectl delete pod istio-pilot-657cb5ddf7-9c6nv -n istio-system
+pod "istio-pilot-657cb5ddf7-9c6nv" deleted
 ```
 
-* To disable mTLS for connections accessing a specific service (since mTLS is triggered by the server-side proxy requesting a client certificate), add an `auth.istio.io/<port#>: NONE` annotation to the service definition:
+After Istio Pilot is restarted, the Guestbook user interface should display correctly.
+
+* We can now gradually enable mTLS on individual services. For example, in the case of Guestbook we can enable mTLS for the guestbook service:
+
+```sh
+kubectl edit service guestbook
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    auth.istio.io/3000: MUTUAL_TLS
+  ...
+spec:
+  ports:
+    - name: http
+      targetPort: 3000
+  ...
+```
+
+* Note that annotations also be used to disable mTLS for connections accessing a specific service. Since mTLS is triggered by the server-side proxy requesting a client certificate, add an `auth.istio.io/<port#>: NONE` annotation to the service definition. For example, to disable mTLS on guestbook and analyzer:
 
 ```sh
 kubectl edit service guestbook
@@ -126,8 +165,6 @@ spec:
   ...
 ```
 
-Note that the annotations can also be used to gradually enable mTLS on individual services.
-
 ## Quiz
 
 **True or False?**
@@ -148,4 +185,4 @@ Note that the annotations can also be used to gradually enable mTLS on individua
 
 * [Istio Concept](https://istio.io/docs/concepts/security/mutual-tls.html)
 
-#### [Continue to Exercise 8 - Policy Enforcement ](../exercise-8/README.md)
+## [Continue to Exercise 8 - Policy Enforcement](../exercise-8/README.md)

--- a/workshop/exercise-8/README.md
+++ b/workshop/exercise-8/README.md
@@ -1,16 +1,16 @@
-# Exercise 8 - Policy Enforcement
+# Exercise 8 - Enforce policies for microservices
 
-Backend systems such as access control systems, telemetry capturing systems, quota enforcement systems, billing systems, and so forth, traditionally directly integrate with Services, creating a hard coupling and baking-in specific semantics and usage options.
+Backend systems such as access control systems, telemetry capturing systems, quota enforcement systems, billing systems, and so forth, traditionally directly integrate with services, creating a hard coupling and baking-in specific semantics and usage options.
 
-Mixer provides a generic intermediation layer between application code and infrastructure backends. Its design moves policy decisions out of the app layer and into configuration instead, under operator control. Instead of having application code integrate with specific backends, the app code instead does a fairly simple integration with Mixer, and Mixer takes responsibility for interfacing with the backend systems.
+Istio Mixer provides a generic intermediation layer between app code and infrastructure backends. Its design moves policy decisions out of the app layer and into configuration instead, under operator control. Instead of having app code integrate with specific backends, the app code instead does a fairly simple integration with Mixer, and Mixer takes responsibility for interfacing with the backend systems.
 
-Given that individual infrastructure backends each have different interfaces and operational models, Mixer needs custom code to deal with each and we call these custom bundles of code **adapters**. Here are some built-in apapters: denier, prometheus,  memquota, stackdriver.
+Given that individual infrastructure backends each have different interfaces and operational models, Mixer needs custom code to deal with each and we call these custom bundles of code **adapters**. Here are some built-in adapters: denier, prometheus,  memquota, and stackdriver.
 
 In this exercise we'll use the denier adapter.
 
-## Service isolation
+## Service isolation with the denier adapter
 
-1. Block access to Guestbook service
+1. Block access to Guestbook service:
 
     ```sh
     istioctl create -f mixer-rule-denial.yaml
@@ -66,11 +66,11 @@ In this exercise we'll use the denier adapter.
     istioctl delete -f mixer-rule-denial.yaml
     ```
 ## Quiz
-1. Does creating mixer rules require application code changes? (Yes/No) No
+1. Does creating mixer rules require app code changes? (Yes/No) No
 2. The custom code that interacts with the backend system, i.e. Prometheus, is called 
 A. Rule B. Instance C. Adapter
 Answer is C
 
-## Further Reading
+## Further reading
 [Istio Mixer](https://istio.io/docs/concepts/policy-and-control/mixer.html)    
 [How to write istio mixer policies](https://medium.com/@szihai_37982/how-to-write-istio-mixer-policies-50dc639acf75)


### PR DESCRIPTION
Fixes #39 

- Clarifiying notes and reference to istio.io FAQ
- instructions to skip mTLS verification on Guestbook while above issue is pending
- instructions for disabling mtls auth globally and enabling for guestbook