### PR TITLE
update traffic management section for 0.8 release

### DIFF
--- a/workshop/README.md
+++ b/workshop/README.md
@@ -1,4 +1,4 @@
-# Beyond the Basics: Istio and IBM Cloud Container Service 
+# Beyond the Basics: Istio and IBM Cloud Container Service
 [Istio](https://www.ibm.com/cloud/info/istio) is an open platform to connect, secure, and manage a network of microservices, also known as a service mesh, on cloud platforms such as Kubernetes in IBM Cloud Container Service. With Istio, You can manage network traffic, load balance across microservices, enforce access policies, verify service identity on the service mesh, and more.
 
 In this course, you can see how to install Istio alongside microservices for a simple mock app called Guestbook. When you deploy Guestbook's microservices into an IBM Cloud Container Service cluster where Istio is installed, you inject the Istio Envoy sidecar proxies in the pods of each microservice.
@@ -6,7 +6,7 @@ In this course, you can see how to install Istio alongside microservices for a s
 **Note**: Some configurations and features of the Istio platform are still under development and are subject to change based on user feedback. Allow a few months for stablilization before you use Istio in production.
 
 ## Objectives
-After you complete this course, you'll be able to: 
+After you complete this course, you'll be able to:
 - Download and install Istio in your cluster
 - Deploy the Guestbook sample app
 - Set up the Istio Ingress controller
@@ -20,7 +20,9 @@ You must you must have a Trial, Pay-As-You-Go, or Subscription [IBM Cloud accoun
 
 Use Kubernetes 1.9.x or newer because earlier versions may require changes in manifests.
 
-You must have [already created a cluster](https://console.bluemix.net/docs/containers/container_index.html#container_index) in IBM Cloud Container Service. 
+You must have [already created a cluster](https://console.bluemix.net/docs/containers/container_index.html#container_index) in IBM Cloud Container Service.
+
+If you are using a Trial IBM Cloud Account, be aware that you may encounter resource caps, especially if there are existing resources in your cluster.  During the course, if any pods remain in `Pending` status, you may need to adjust the number of `replicas` in the various deployment yamls to a value of 1, delete the deployment, and attempt the steps again.
 
 You should have a basic understanding of containers, IBM Cloud Container Service, and Istio. If you have no experience with those, take the following courses:
 1. [Get started with Kubernetes and IBM Cloud Container Service](https://developer.ibm.com/courses/all/get-started-kubernetes-ibm-cloud-container-service/)

--- a/workshop/exercise-2/README.md
+++ b/workshop/exercise-2/README.md
@@ -12,9 +12,9 @@ export PATH=$PWD/istio-<version-number>/bin:$PATH
 ```
 4. Change the directory to the Istio file location.
 
-5. Install Istio on the Kubernetes cluster. Istio is deployed in the Kubernetes namespace `istio-system`. Since in a later exercise we will try out the mutual TLS features, we install the `istio-auth.yaml` here.
+5. Install Istio on the Kubernetes cluster. Istio is deployed in the Kubernetes namespace `istio-system`. Since in a later exercise we will try out the mutual TLS features, we install the `istio-demo-auth.yaml` here.
 ```bash
-kubectl apply -f install/kubernetes/istio.yaml
+kubectl apply -f install/kubernetes/istio-demo.yaml
 ```
 
 6. Ensure that the Kubernetes services `istio-ingress`, `istio-mixer`, and `istio-pilot` are fully deployed before you continue.

--- a/workshop/exercise-3/README.md
+++ b/workshop/exercise-3/README.md
@@ -46,22 +46,22 @@ The Redis database is a service that you can use to persist the data of your app
   ```
 ## Sidecar injection
 
-In Kubernetes, a sidecar is a utility container in the pod, and its purpose is to support the main container. For Istio to work, Envoy proxies must be deployed as sidecars to each pod of the deployment. There are two ways of injecting the Istio sidecar into a pod: manually using istioctl CLI tool or automatically using the Istio Initializer. In this exercise, we will use the manual injection. Manual injection modifies the controller configuration, e.g. deployment. It does this by modifying the pod template spec such that all pods for that deployment are created with the injected sidecar. 
+In Kubernetes, a sidecar is a utility container in the pod, and its purpose is to support the main container. For Istio to work, Envoy proxies must be deployed as sidecars to each pod of the deployment. There are two ways of injecting the Istio sidecar into a pod: manually using istioctl CLI tool or automatically using the Istio Initializer. In this exercise, we will use the manual injection. Manual injection modifies the controller configuration, e.g. deployment. It does this by modifying the pod template spec such that all pods for that deployment are created with the injected sidecar.
 
 ## Install the Guestbook app with manual sidecar injection
 
   ```sh
- kubectl apply -f <(istioctl kube-inject -f ../v1/guestbook-deployment.yaml --debug)
- kubectl apply -f <(istioctl kube-inject -f guestbook-deployment.yaml --debug)
+ kubectl apply -f <(istioctl kube-inject -f ../v1/guestbook-deployment.yaml)
+ kubectl apply -f <(istioctl kube-inject -f guestbook-deployment.yaml)
   ```
 These commands will inject the Istio Envoy sidecar into the guestbook pods, as well as deploy the Guestbook app on to the Kubernetes cluster. Here we have two versions of deployments, a new version (`v2`) in the current directory, and a previous version (`v1`) in a sibling directory. They will be used in future sections to showcase the Istio traffic routing capabilities.
-  
+
 Next, we'll create the guestbook service.
 
 1. Inject the Istio Envoy sidecar into the guestbook pods, and deploy the Guestbook app on to the Kubernetes cluster.
 ```sh
-kubectl apply -f <(istioctl kube-inject -f ../v1/guestbook-deployment.yaml --debug)
-kubectl apply -f <(istioctl kube-inject -f guestbook-deployment.yaml --debug)
+kubectl apply -f <(istioctl kube-inject -f ../v1/guestbook-deployment.yaml)
+kubectl apply -f <(istioctl kube-inject -f guestbook-deployment.yaml)
 ```
 
 2. Create the guestbook service.
@@ -92,21 +92,21 @@ guestbook-v2-56d98b558c-mzbxk   2/2       Running   0          5d
 Note that each guestbook pod has 2 containers in it. One is the guestbook container, and the other is the Envoy proxy sidecar.
 
 ### Add Watson Tone Analyzer
-Watson Tone Analyzer detects the tone from the words that users enter into the Guestbook app. The tone is converted to the corresponding emoticons. 
+Watson Tone Analyzer detects the tone from the words that users enter into the Guestbook app. The tone is converted to the corresponding emoticons.
 
-1. Use `bx target --cf` or `bx target -o ORG -s SPACE` to set the Cloud Foundry org and space where you want to provision the service. 
+1. Use `bx target --cf` or `bx target -o ORG -s SPACE` to set the Cloud Foundry org and space where you want to provision the service.
 
-2. Create Watson Tone Analyzer in your space. 
+2. Create Watson Tone Analyzer in your space.
       ```console
       bx service create tone_analyzer lite my-tone-analyzer-service
       ```
-      
-3. Create a service key for the service. 
+
+3. Create a service key for the service.
       ```console
       bx service key-create my-tone-analyzer-service myKey
       ```
-   
-4. Show the service key that you created and note the **password** and **username**. 
+
+4. Show the service key that you created and note the **password** and **username**.
       ```console
       bx service key-show my-tone-analyzer-service myKey
       ```
@@ -117,14 +117,10 @@ Watson Tone Analyzer detects the tone from the words that users enter into the G
 
 7. Deploy the analyzer pods and service. The analyzer service talks to Watson Tone Analyzer to help analyze the tone of a message.
    ```console
-   kubectl apply -f analyzer-deployment.yaml
+   kubectl apply -f <(istioctl kube-inject -f analyzer-deployment.yaml)
    kubectl apply -f analyzer-service.yaml
    ```
-   
-5. Create an egress rule to allow the analyzer service to access Watson Tone Analyzer. The rule is defined in [istio101/workshop/plans](https://github.com/IBM/istio101/tree/master/workshop/plans) and is not part of the Guestbook app files:
-    ```console
-      kubectl apply -f analyzer-egress.yaml
-    ```
-Great! With you Guestbook up and running, you can now expose the service mesh with the Istio Ingress controller. 
+   Great! With your Guestbook up and running, you can now expose the service mesh with the Istio Ingress controller. 
+
 
 #### [Continue to Exercise 4 - Expose the service mesh with the Istio Ingress controller](../exercise-4/README.md)

--- a/workshop/exercise-4/README.md
+++ b/workshop/exercise-4/README.md
@@ -50,7 +50,7 @@ A Kubernetes Ingress rule can be created that routes external requests through t
 1. Configure the guestbook default route with the Istio Ingress controller.
 
     ```sh
-    kubectl apply -f guestbook-ingress.yaml
+    istioctl create -f guestbook-gateway.yaml
     ```
 
 2. Now check the node port of the ingress.
@@ -61,7 +61,7 @@ A Kubernetes Ingress rule can be created that routes external requests through t
     istio-ingress   LoadBalancer                    *              80:31702/TCP,443:32290/TCP   10d
 
 
-    bx cs workers guestbook
+    bx cs workers <cluster_name>
 
     ID             Public IP      Private IP      Machine Type        State    Status   Zone    Version   
     kube-xxx       169.60.87.20   10.188.80.69    u2c.2x4.encrypted   normal   Ready    wdc06   1.9.7_1510*   
@@ -85,7 +85,7 @@ The IBM Ingress service provides IBM Cloud users with a secure, reliable, and sc
 
 1. Let's first check the IBM Ingress subdomain information.
 ```sh
-bx cs cluster-get guestbook
+bx cs cluster-get <cluster_name>
 
 ...
 Ingress subdomain:	guestbook-242887.us-east.containers.mybluemix.net

--- a/workshop/exercise-4/README.md
+++ b/workshop/exercise-4/README.md
@@ -31,17 +31,17 @@ A Kubernetes Ingress rule can be created that routes external requests through t
     Events:                         <none>
     ```
 
-2. Get the **EXTERNAL-IP** of the Istio Ingress controller. 
+2. Get the **EXTERNAL-IP** of the Istio Ingress controller.
 
     ```sh
-    kubectl get service istio-ingress -n istio-system
+    kubectl get service istio-ingressgateway -n istio-system
 
     NAME            TYPE           CLUSTER-IP       EXTERNAL-IP     PORT(S)                      AGE
     istio-ingress   LoadBalancer   172.21.126.221   169.61.37.141   80:31432/TCP,443:31753/TCP   3h
     ```
-    
-3. Access the Guestbook app by using the external IP address that you retrieved in the previous step. 
-   Example: 
+
+3. Access the Guestbook app by using the external IP address that you retrieved in the previous step.
+   Example:
    ```
    http://169.61.37.141
    ```
@@ -55,33 +55,33 @@ A Kubernetes Ingress rule can be created that routes external requests through t
 
 2. Now check the node port of the ingress.
     ```sh
-    kubectl get svc istio-ingress -n istio-system
-    
+    kubectl get svc istio-ingressgateway -n istio-system
+
     NAME            TYPE           CLUSTER-IP       EXTERNAL-IP    PORT(S)                      AGE
     istio-ingress   LoadBalancer                    *              80:31702/TCP,443:32290/TCP   10d
-    
-    
+
+
     bx cs workers guestbook
-    
+
     ID             Public IP      Private IP      Machine Type        State    Status   Zone    Version   
     kube-xxx       169.60.87.20   10.188.80.69    u2c.2x4.encrypted   normal   Ready    wdc06   1.9.7_1510*   
 
     ```
  The node port in above sample output is `169.60.87.20:31702`.
- 
- 3. Access the Guestbook app by using the node port that you retrieved in the previous step. 
-   Example: 
+
+ 3. Access the Guestbook app by using the node port that you retrieved in the previous step.
+   Example:
    ```
    http://169.60.72.58:31702
    ```
- 
+
 ## (Optional) Set up the Istio Ingress controller to work with IBM Cloud Container Service
 
-**Note:** This task requires a standard cluster. 
+**Note:** This task requires a standard cluster.
 
-To have an IBM-provided DNS for the Guestbook app, you must set up the Istio Ingress controller to route traffic to the Kubernetes Ingress application load balancer (ALB). 
+To have an IBM-provided DNS for the Guestbook app, you must set up the Istio Ingress controller to route traffic to the Kubernetes Ingress application load balancer (ALB).
 
-The IBM Ingress service provides IBM Cloud users with a secure, reliable, and scalable network stack to distribute incoming network traffic to apps in IBM Cloud. You can enhance the IBM-provided Ingress application load balancer by adding annotions. Learn more about [Ingress for IBM Cloud Container Service](https://console.bluemix.net/docs/containers/cs_ingress.html#ingress). 
+The IBM Ingress service provides IBM Cloud users with a secure, reliable, and scalable network stack to distribute incoming network traffic to apps in IBM Cloud. You can enhance the IBM-provided Ingress application load balancer by adding annotions. Learn more about [Ingress for IBM Cloud Container Service](https://console.bluemix.net/docs/containers/cs_ingress.html#ingress).
 
 1. Let's first check the IBM Ingress subdomain information.
 ```sh
@@ -93,16 +93,16 @@ Ingress subdomain:	guestbook-242887.us-east.containers.mybluemix.net
 
 2. Add the subdomain that you retrieved in the previous step as `host` in the `guestbook-frontdoor.yaml` file.
 
-3. Create the Ingress with the IBM-provided subdomain. 
+3. Create the Ingress with the IBM-provided subdomain.
    ```sh
    kubectl apply -f guestbook-frontdoor.yaml
    ```
-   
-4. List the details for your Ingress. 
+
+4. List the details for your Ingress.
    ```sh
    kubectl get ingress guestbook-ingress  -o yaml
    ```
-   Example output: 
+   Example output:
    ```sh
    apiVersion: extensions/v1beta1
    kind: Ingress
@@ -120,16 +120,16 @@ Ingress subdomain:	guestbook-242887.us-east.containers.mybluemix.net
                  serviceName: guestbook
                  servicePort: 3000
    ```
-   
-5. Use the IBM-provided subdomain to access your Guestbook app. 
-   Example: 
+
+5. Use the IBM-provided subdomain to access your Guestbook app.
+   Example:
    ```
    http://[guestbook].us-east.containers.mybluemix.net
    ```
-   
-Congratulations! You extended the base Ingress features by providing a DNS entry to the Istio service. 
-   
-## References: 
+
+Congratulations! You extended the base Ingress features by providing a DNS entry to the Istio service.
+
+## References:
 [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/)           
 [Istio Ingress](https://istio.io/docs/tasks/traffic-management/ingress.html)
 

--- a/workshop/exercise-6/README.md
+++ b/workshop/exercise-6/README.md
@@ -19,7 +19,7 @@ In the Guestbook app, there is one service: guestbook.  The guestbook service ha
 A/B testing is a method of performing identical tests against two separate service versions in order to determine which performs better.  To prevent Istio from performing the default routing behavior between the original and modernized guestbook service, define the following rules (found in [istio101/workshop/plans](https://github.com/IBM/istio101/tree/master/workshop/plans)):
 
 ```console
-  kubectl apply -f virtualservice-all-v1.yaml
+istioctl create -f virtualservice-all-v1.yaml
 ```
 
 ```yaml
@@ -40,7 +40,7 @@ spec:
 ```
 
 ```console
-  kubectl apply -f guestbook-destination.yaml
+istioctl create -f guestbook-destination.yaml
 ```
 
 ```yaml
@@ -64,7 +64,7 @@ The `VirtualService` defines a rule that captures all HTTP traffic coming in thr
 To enable the Istio service mesh for A/B testing against the new service version, modify the original `VirtualService` rule:
 
 ```console
-  kubectl apply -f virtualservice-test.yaml
+istioctl replace -f virtualservice-test.yaml
 ```
 
 ```yaml
@@ -97,7 +97,7 @@ In Istio `VirtualService` rules, there can be only one rule for each service and
 The newer version of the guestbook service call the Watson Tone Analyzer service created in [Exercise 3](../exercise-3/README.md).  By default Istio blocks calls to services outside the service mesh.  In order for calls to reach the Watson service, create the following `ServiceEntry`:
 
 ```console
-  kubectl apply -f serviceentry-tone.yaml
+istioctl create -f serviceentry-tone.yaml
 ```
 
 ```yaml
@@ -137,7 +137,7 @@ If two browsers are available on your system, observe the modernized guestbook s
 In `Canary Deployments`, newer versions of services are incrementally rolled out to users to minimize the risk and impact of any bugs introduced by the newer version.  To begin incrementally routing traffic to the newer version of the guestbook service, modify the original `VirtualService` rule:
 
 ```console
-  kubectl apply -f virtualservice-80-20.yaml
+istioctl replace -f virtualservice-80-20.yaml
 ```
 
 ```yaml

--- a/workshop/exercise-6/README.md
+++ b/workshop/exercise-6/README.md
@@ -16,7 +16,11 @@ A [ServiceEntry](https://istio.io/docs/reference/config/istio.networking.v1alpha
 In the Guestbook app, there is one service: guestbook.  The guestbook service has two distinct versions: the base version (version 1) and the modernized version (version 2).  Each version of the service has three instances based on the number of replicas in [guestbook-deployment.yaml](https://github.com/linsun/examples/blob/master/guestbook-go/guestbook-deployment.yaml) and [guestbook-v2-deployment.yaml](https://github.com/linsun/examples/blob/master/guestbook-go/guestbook-v2-deployment.yaml).  By default, prior to creating any rules, Istio will route requests equally across version 1 and version 2 of the guestbook service and their respective instances in a round robin manner.  However, new versions of a service can easily introduce bugs to the service mesh, so following A/B Testing and Canary Deployments is good practice.
 
 ### A/B testing with Istio
-A/B testing is a method of performing identical tests against two separate service versions in order to determine which performs better.  To prevent Istio from performing the default routing behavior between the original and modernized guestbook service, define the following rules:
+A/B testing is a method of performing identical tests against two separate service versions in order to determine which performs better.  To prevent Istio from performing the default routing behavior between the original and modernized guestbook service, define the following rules (found in [istio101/workshop/plans](https://github.com/IBM/istio101/tree/master/workshop/plans)):
+
+```console
+  kubectl apply -f virtualservice-all-v1.yaml
+```
 
 ```yaml
 apiVersion: networking.istio.io/v1alpha3
@@ -25,33 +29,43 @@ metadata:
   name: virtual-service-guestbook
 spec:
   hosts:
-  - guestbook
+    - '*'
+  gateways:
+    - guestbook-gateway
   http:
-  - route:
-    - destination:
-        host: guestbook
-        subset: v1
+    - route:
+        - destination:
+            host: guestbook
+            subset: v1
+```
+
+```console
+  kubectl apply -f guestbook-destination.yaml
 ```
 
 ```yaml
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
-  name: destination-rule-guestbook
+  name: destination-guestbook
 spec:
   host: guestbook
   subsets:
-  - name: v1
-    labels:
-      version: v1
-  - name: v2
-    labels:
-      version: v2
+    - name: v1
+      labels:
+        version: '1.0'
+    - name: v2
+      labels:
+        version: '2.0'
 ```
 
-The `VirtualService` defines a rule that captures all HTTP traffic going to hostname `guestbook` and routes 100% of the traffic to pods of the guestbook service with label "version: v1".  A subset or version of a route destination is identified with a reference to a named service subset which must be declared in a corresponding `DestinationRule`.  Since there are three instances matching the criteria of hostname `guestbook` and subset `version: v1`, by default Envoy will send traffic to all three instances in a round robin manner.
+The `VirtualService` defines a rule that captures all HTTP traffic coming in through the Istio ingress gateway, `guestbook-gateway`, and routes 100% of the traffic to pods of the guestbook service with label "version: v1".  A subset or version of a route destination is identified with a reference to a named service subset which must be declared in a corresponding `DestinationRule`.  Since there are three instances matching the criteria of hostname `guestbook` and subset `version: v1`, by default Envoy will send traffic to all three instances in a round robin manner.  You can view the guestbook service UI using the IP address and port obtained in [Exercise 4](../exercise-4/README.md) and enter it as a URL in Firefox or Chrome web browsers.
 
 To enable the Istio service mesh for A/B testing against the new service version, modify the original `VirtualService` rule:
+
+```console
+  kubectl apply -f virtualservice-test.yaml
+```
 
 ```yaml
 apiVersion: networking.istio.io/v1alpha3
@@ -60,27 +74,72 @@ metadata:
   name: virtual-service-guestbook
 spec:
   hosts:
-  - guestbook
+    - '*'
+  gateways:
+    - guestbook-gateway
   http:
-  - match:
-    - headers:
-        istio-test-header:
-          exact: "version2"
-    route:
-    - destination:
-        host: guestbook
-        subset: v2
-  - route:
-    - destination:
-        host: guestbook
-        subset: v1
+    - match:
+        - headers:
+            user-agent:
+              regex: '.*Firefox.*'
+      route:
+        - destination:
+            host: guestbook
+            subset: v2
+    - route:
+        - destination:
+            host: guestbook
+            subset: v1
 ```
 
-In Istio `VirtualService` rules, there can be only one rule for each service and therefore when defining multiple [HTTPRoute](https://istio.io/docs/reference/config/istio.networking.v1alpha3.html#HTTPRoute) blocks, the order in which they are defined in the yaml matters.  With the modified rule, incoming requests going to hostname `guestbook` that contain a header `istio-test-header` with value `version2` will go to the newer version of guestbook.  All other requests fall-through to the next block, which routes all traffic to the original version of guestbook.  This way the same performance tests and functionality tests can be used to run against version 1 and version 2 just by appending a header.
+In Istio `VirtualService` rules, there can be only one rule for each service and therefore when defining multiple [HTTPRoute](https://istio.io/docs/reference/config/istio.networking.v1alpha3.html#HTTPRoute) blocks, the order in which they are defined in the yaml matters.  Hence, the original `VirtualService` rule is modified rather than creating a new rule.  With the modified rule, incoming requests originating from `Firefox` browsers will go to the newer version of guestbook.  All other requests fall-through to the next block, which routes all traffic to the original version of guestbook.  
+
+The newer version of the guestbook service call the Watson Tone Analyzer service created in [Exercise 3](../exercise-3/README.md).  By default Istio blocks calls to services outside the service mesh.  In order for calls to reach the Watson service, create the following `ServiceEntry`:
+
+```console
+  kubectl apply -f serviceentry-tone.yaml
+```
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: bluemix-tone-analyzer
+spec:
+  hosts:
+  - "gateway.watsonplatform.net"
+  ports:
+  - number: 80
+    name: https
+    protocol: http
+  resolution: DNS
+  endpoints:
+   - address: gateway.watsonplatform.net
+     ports:
+       https: 443
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: bluemix-tone-analyzer
+spec:
+  host: "gateway.watsonplatform.net"
+  trafficPolicy:
+    tls:
+      mode: SIMPLE # initiates HTTPS when talking to gateway.watsonplatform.net
+```
+
+The `ServiceEntry` defines addresses and ports services within the mesh are allowed to make requests to.  A `DestinationRule` is also created.  This is required because the guestbook service makes calls over HTTP, but the Watson service only accepts HTTPS connections.  The `DestinationRule` tells Istio to convert the outgoing HTTP request to HTTPS.
+
+If two browsers are available on your system, observe the modernized guestbook service in Firefox and the original guestbook service in any other browser.
 
 ### Canary deployment
 In `Canary Deployments`, newer versions of services are incrementally rolled out to users to minimize the risk and impact of any bugs introduced by the newer version.  To begin incrementally routing traffic to the newer version of the guestbook service, modify the original `VirtualService` rule:
 
+```console
+  kubectl apply -f virtualservice-80-20.yaml
+```
+
 ```yaml
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -88,17 +147,19 @@ metadata:
   name: virtual-service-guestbook
 spec:
   hosts:
-  - guestbook
+    - '*'
+  gateways:
+    - guestbook-gateway
   http:
     - route:
-      - destination:
-          host: guestbook
-          subset: v1
-        weight: 80
-      - destination:
-          host: guestbook
-          subset: v2
-        weight: 20
+        - destination:
+            host: guestbook
+            subset: v1
+          weight: 80
+        - destination:
+            host: guestbook
+            subset: v2
+          weight: 20
 ```
 
 In the modified rule, the routed traffic is split between two different subsets of the guestbook service.  In this manner, traffic to the modernized version 2 of guestbook is controlled on a percentage basis to limit the impact of any unforeseen bugs.  This rule can be modified over time until eventually all traffic is directed to the newer version of the service.

--- a/workshop/exercise-6/README.md
+++ b/workshop/exercise-6/README.md
@@ -109,29 +109,13 @@ spec:
   hosts:
   - "gateway.watsonplatform.net"
   ports:
-  - number: 80
+  - number: 443
     name: https
-    protocol: http
+    protocol: https
   resolution: DNS
-  endpoints:
-   - address: gateway.watsonplatform.net
-     ports:
-       https: 443
----
-apiVersion: networking.istio.io/v1alpha3
-kind: DestinationRule
-metadata:
-  name: bluemix-tone-analyzer
-spec:
-  host: "gateway.watsonplatform.net"
-  trafficPolicy:
-    tls:
-      mode: SIMPLE # initiates HTTPS when talking to gateway.watsonplatform.net
 ```
 
-The `ServiceEntry` defines addresses and ports services within the mesh are allowed to make requests to.  A `DestinationRule` is also created.  This is required because the guestbook service makes calls over HTTP, but the Watson service only accepts HTTPS connections.  The `DestinationRule` tells Istio to convert the outgoing HTTP request to HTTPS.
-
-If two browsers are available on your system, observe the modernized guestbook service in Firefox and the original guestbook service in any other browser.
+The `ServiceEntry` defines addresses and ports services within the mesh are allowed to make requests to.  If two browsers are available on your system, observe the modernized guestbook service in Firefox and the original guestbook service in any other browser.
 
 ### Canary deployment
 In `Canary Deployments`, newer versions of services are incrementally rolled out to users to minimize the risk and impact of any bugs introduced by the newer version.  To begin incrementally routing traffic to the newer version of the guestbook service, modify the original `VirtualService` rule:

--- a/workshop/plans/guestbook-destination.yaml
+++ b/workshop/plans/guestbook-destination.yaml
@@ -1,0 +1,13 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: destination-rule-guestbook
+spec:
+  host: guestbook
+  subsets:
+  - name: v1
+    labels:
+      version: "1.0"
+  - name: v2
+    labels:
+      version: "2.0"

--- a/workshop/plans/guestbook-gateway.yaml
+++ b/workshop/plans/guestbook-gateway.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: guestbook-gateway
+spec:
+  selector:
+    istio: ingressgateway # use istio default controller
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"

--- a/workshop/plans/serviceentry-tone.yaml
+++ b/workshop/plans/serviceentry-tone.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: bluemix-tone-analyzer
+spec:
+  hosts:
+  - "gateway.watsonplatform.net"
+  ports:
+  - number: 80
+    name: https
+    protocol: http
+  resolution: DNS
+  endpoints:
+   - address: gateway.watsonplatform.net
+     ports:
+       https: 443
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: bluemix-tone-analyzer
+spec:
+  host: "gateway.watsonplatform.net"
+  trafficPolicy:
+    tls:
+      mode: SIMPLE # initiates HTTPS when talking to gateway.watsonplatform.net

--- a/workshop/plans/serviceentry-tone.yaml
+++ b/workshop/plans/serviceentry-tone.yaml
@@ -6,21 +6,7 @@ spec:
   hosts:
   - "gateway.watsonplatform.net"
   ports:
-  - number: 80
+  - number: 443
     name: https
-    protocol: http
+    protocol: https
   resolution: DNS
-  endpoints:
-   - address: gateway.watsonplatform.net
-     ports:
-       https: 443
----
-apiVersion: networking.istio.io/v1alpha3
-kind: DestinationRule
-metadata:
-  name: bluemix-tone-analyzer
-spec:
-  host: "gateway.watsonplatform.net"
-  trafficPolicy:
-    tls:
-      mode: SIMPLE # initiates HTTPS when talking to gateway.watsonplatform.net

--- a/workshop/plans/virtualservice-80-20.yaml
+++ b/workshop/plans/virtualservice-80-20.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: virtual-service-guestbook
+spec:
+  hosts:
+    - '*'
+  gateways:
+    - guestbook-gateway
+  http:
+    - route:
+        - destination:
+            host: guestbook
+            subset: v1
+          weight: 80
+        - destination:
+            host: guestbook
+            subset: v2
+          weight: 20

--- a/workshop/plans/virtualservice-all-v1.yaml
+++ b/workshop/plans/virtualservice-all-v1.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: virtual-service-guestbook
+spec:
+  hosts:
+    - '*'
+  gateways:
+    - guestbook-gateway
+  http:
+    - route:
+        - destination:
+            host: guestbook
+            subset: v1

--- a/workshop/plans/virtualservice-test.yaml
+++ b/workshop/plans/virtualservice-test.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: virtual-service-guestbook
+spec:
+  hosts:
+    - '*'
+  gateways:
+    - guestbook-gateway
+  http:
+    - match:
+        - headers:
+            user-agent:
+              regex: '.*Firefox.*'
+      route:
+        - destination:
+            host: guestbook
+            subset: v2
+    - route:
+        - destination:
+            host: guestbook
+            subset: v1


### PR DESCRIPTION
still missing: where to create the `workshop/plans/guestbook-gateway.yaml`, step 4 or during Traffic Management section

some additional bug fixes:
* removed the `--debug` flag from the istioctl commands as the flag is deprecated
* was missing a kube-inject command when creating the analyzer deployment

