### PR TITLE
denier and checknothing converted to handler and instance

### DIFF
--- a/workshop/exercise-8/README.md
+++ b/workshop/exercise-8/README.md
@@ -18,36 +18,36 @@ In this exercise we'll use the denier adapter.
 
     Let's examine the rule:
     ```yaml
-        apiVersion: "config.istio.io/v1alpha2"
-        kind: denier
-        metadata:
-          name: denyall
-          namespace: istio-system
-        spec:
-          status:
-            code: 7
-            message: Not allowed
-        ---
-        # The (empty) data handed to denyall at run time
-        apiVersion: "config.istio.io/v1alpha2"
-        kind: checknothing
-        metadata:
-          name: denyrequest
-          namespace: istio-system
-        spec:
-        ---
-        # The rule that uses denier to deny requests to the guestbook service
-        apiVersion: "config.istio.io/v1alpha2"
-        kind: rule
-        metadata:
-          name: deny-hello-world
-          namespace: istio-system
-        spec:
-          match: destination.service=="guestbook.default.svc.cluster.local"
-          actions:
-          - handler: denyall.denier
-            instances:
-            - denyrequest.checknothing
+    apiVersion: "config.istio.io/v1alpha2"
+    kind: handler
+    metadata:
+      name: denyall
+    spec:
+      compiledAdapter: denier
+      params:
+        status:
+          code: 7
+          message: Not allowed
+    ---
+    # The (empty) data handed to denyall at run time
+    apiVersion: "config.istio.io/v1alpha2"
+    kind: instance
+    metadata:
+      name: denyrequest
+    spec:
+      compiledTemplate: checknothing
+    ---
+    # The rule that uses denier to deny requests to the guestbook service
+    apiVersion: "config.istio.io/v1alpha2"
+    kind: rule
+    metadata:
+      name: deny-guestbook
+    spec:
+      match: destination.service.name == "guestbook"
+      actions:
+      - handler: denyall
+        instances:
+        - denyrequest
     ```
 
 2. Verify that the service is denied:

--- a/workshop/plans/mixer-rule-denial.yaml
+++ b/workshop/plans/mixer-rule-denial.yaml
@@ -1,18 +1,21 @@
 apiVersion: "config.istio.io/v1alpha2"
-kind: denier
+kind: handler
 metadata:
   name: denyall
 spec:
-  status:
-    code: 7
-    message: Not allowed
+  compiledAdapter: denier
+  params:
+    status:
+      code: 7
+      message: Not allowed
 ---
 # The (empty) data handed to denyall at run time
 apiVersion: "config.istio.io/v1alpha2"
-kind: checknothing
+kind: instance
 metadata:
   name: denyrequest
 spec:
+  compiledTemplate: checknothing
 ---
 # The rule that uses denier to deny requests to the guestbook service
 apiVersion: "config.istio.io/v1alpha2"
@@ -20,8 +23,8 @@ kind: rule
 metadata:
   name: deny-guestbook
 spec:
-  match: destination.service.name=="guestbook"
+  match: destination.service.name == "guestbook"
   actions:
-  - handler: denyall.denier
+  - handler: denyall
     instances:
-    - denyrequest.checknothing
+    - denyrequest


### PR DESCRIPTION
The error was:

```
$ kubectl create -f mixer-rule-denial.yaml
rule.config.istio.io/deny-guestbook created
unable to recognize "mixer-rule-denial.yaml": no matches for kind "denier" in version "config.istio.io/v1alpha2"
unable to recognize "mixer-rule-denial.yaml": no matches for kind "checknothing" in version "config.istio.io/v1alpha2"
```
```bash
$ istioctl validate -f mixer-rule-denial.yaml
2019-11-17T22:59:12.918021Z     warn    deprecated Mixer kind "denier", please use "handler" or "instance" instead
2019-11-17T22:59:12.918855Z     warn    deprecated Mixer kind "checknothing", please use "handler" or "instance" instead
Error: 1 error occurred:
        * rule//deny-guestbook: rule='deny-guestbook.rule.'.Match: unknown attribute destination.service.name
```