### PR TITLE
markdown fixes

### DIFF
--- a/workshop/exercise-1/README.md
+++ b/workshop/exercise-1/README.md
@@ -4,22 +4,23 @@ You must already have a [cluster created](https://cloud.ibm.com/docs/containers?
 
 ## Install IBM Cloud Kubernetes Service command line utilities
 
-1.  Download and install the required CLI tools.
+1. Download and install the required CLI tools.
 
     ```shell
     curl -sL https://ibm.biz/idt-installer | bash
     ```
 
-2.  Log in to the IBM Cloud CLI. (If you have a federated account, include the `--sso` flag.)
+1. Log in to the IBM Cloud CLI. (If you have a federated account, include the `--sso` flag.)
 
     ```shell
     ibmcloud login
     ```
 
 ## Access your cluster
+
 Learn how to set the context to work with your cluster by using the `kubectl` CLI, access the Kubernetes dashboard, and gather basic information about your cluster.
 
-1.  Set the context for your cluster in your CLI. Every time you log in to the IBM Cloud Kubernetes Service CLI to work with the cluster, you must run these commands to set the path to the cluster's configuration file as a session variable. The Kubernetes CLI uses this variable to find a local configuration file and certificates that are necessary to connect with the cluster in IBM Cloud.
+1. Set the context for your cluster in your CLI. Every time you log in to the IBM Cloud Kubernetes Service CLI to work with the cluster, you must run these commands to set the path to the cluster's configuration file as a session variable. The Kubernetes CLI uses this variable to find a local configuration file and certificates that are necessary to connect with the cluster in IBM Cloud.
 
     a. List the available clusters.
 
@@ -42,11 +43,12 @@ Learn how to set the context to work with your cluster by using the `kubectl` CL
     d. Copy and paste the output command from the previous step to set the `KUBECONFIG` environment variable and configure your CLI to run `kubectl` commands against your cluster.
 
     Example:
+
     ```shell
     export KUBECONFIG=/Users/user-name/.bluemix/plugins/container-service/clusters/mycluster/kube-config-hou02-mycluster.yml
     ```
 
-2.  Get basic information about your cluster and its worker nodes. This information can help you manage your cluster and troubleshoot issues.
+1. Get basic information about your cluster and its worker nodes. This information can help you manage your cluster and troubleshoot issues.
 
     a.  View details of your cluster.
 
@@ -60,7 +62,7 @@ Learn how to set the context to work with your cluster by using the `kubectl` CL
     ibmcloud ks workers $MYCLUSTER
     ```
 
-3.  Validate access to your cluster by viewing the nodes in the cluster.
+1. Validate access to your cluster by viewing the nodes in the cluster.
 
     ```shell
     kubectl get node

--- a/workshop/exercise-2/README.md
+++ b/workshop/exercise-2/README.md
@@ -5,26 +5,29 @@ In this module, you will use the Managed Istio add-on to install Istio on your c
 Managed Istio is available as part of IBM Cloud™ Kubernetes Service. The service provides seamless installation of Istio, automatic updates and lifecycle management of control plane components, and integration with platform logging and monitoring tools.
 
 1. Download the `istioctl` CLI and add it to your PATH:
+
    ```shell
    curl -sL https://raw.githubusercontent.com/istio/istio/release-1.4/release/downloadIstioCtl.sh | sh -
    ```
-   ```
+
+   ```shell
    export PATH=$PATH:$HOME/.istioctl/bin
    ```
 
-2. Enable Managed Istio on your IKS cluster:
+1. Enable Managed Istio on your IKS cluster:
 
     ```shell
     ibmcloud ks cluster addon enable istio --cluster $MYCLUSTER
     ```
 
-3. Ensure that the `istio-*` Kubernetes services are deployed before you continue. This might take up to 5 minutes.
+1. Ensure that the `istio-*` Kubernetes services are deployed before you continue. This might take up to 5 minutes.
 
     ```shell
     kubectl get svc -n istio-system
     ```
 
     Sample output:
+
     ```shell
     NAME                     TYPE           CLUSTER-IP       EXTERNAL-IP     PORT(S)                                                                                                                                      AGE
     grafana                  ClusterIP      172.21.248.16    <none>          3000/TCP                                                                                                                                     2s
@@ -46,14 +49,16 @@ Managed Istio is available as part of IBM Cloud™ Kubernetes Service. The servi
 
     ```
 
-**Note: If your istio-ingressgateway service IP is <pending>, confirm that you are using a standard/paid cluster. Free cluster is not supported for this lab.**
+**Note: If your istio-ingressgateway service IP is &lt;pending>, confirm that you are using a standard/paid cluster. Free cluster is not supported for this lab.**
 
 1. Ensure the corresponding pods `istio-citadel-*`, `istio-ingressgateway-*`, `istio-pilot-*`, and `istio-policy-*` are all in **`Running`** state before you continue.
 
     ```shell
     kubectl get pods -n istio-system
     ```
+
     Sample output:
+
     ```shell
     NAME                                     READY   STATUS    RESTARTS   AGE
     grafana-6c89cb48cf-v767v                 1/1     Running   0          33s
@@ -74,4 +79,4 @@ Managed Istio is available as part of IBM Cloud™ Kubernetes Service. The servi
 
     Congratulations! You successfully installed Istio into your cluster.
 
-#### [Continue to Exercise 3 - Deploy Guestbook with Istio Proxy](../exercise-3/README.md)
+## [Continue to Exercise 3 - Deploy Guestbook with Istio Proxy](../exercise-3/README.md)

--- a/workshop/exercise-3/README.md
+++ b/workshop/exercise-3/README.md
@@ -2,37 +2,40 @@
 
 The Guestbook app is a sample app for users to leave comments. It consists of a web front end, Redis master for storage, and a replicated set of Redis slaves. We will also integrate the app with Watson Tone Analyzer which detects the sentiment in users' comments and replies with emoticons.
 
-![](../README_images/istio1.jpg)
+![Guestbook applicaiton topology](../README_images/istio1.jpg)
 
-### Download the Guestbook app
+## Download the Guestbook app
+
 1. Clone the Guestbook app into the `workshop` directory.
 
     ```shell
     git clone https://github.com/IBM/guestbook.git
     ```
 
-2. Navigate into the app directory.
+1. Navigate into the app directory.
 
     ```shell
     cd guestbook/v2
     ```
 
-### Enable the automatic sidecar injection for the default namespace
+## Enable the automatic sidecar injection for the default namespace
+
 In Kubernetes, a sidecar is a utility container in the pod, and its purpose is to support the main container. For Istio to work, Envoy proxies must be deployed as sidecars to each pod of the deployment. There are two ways of injecting the Istio sidecar into a pod: manually using the istioctl CLI tool or automatically using the Istio sidecar injector. In this exercise, we will use the automatic sidecar injection provided by Istio.
 
 1. Annotate the default namespace to enable automatic sidecar injection:
-    
+
     ``` shell
     kubectl label namespace default istio-injection=enabled
     ```
-    
-2. Validate the namespace is annotated for automatic sidecar injection:
-    
+
+1. Validate the namespace is annotated for automatic sidecar injection:
+
     ``` shell
     kubectl get namespace -L istio-injection
     ```
-    
+
     Sample output:
+
     ``` shell
     NAME             STATUS   AGE    ISTIO-INJECTION
     default          Active   271d   enabled
@@ -40,7 +43,8 @@ In Kubernetes, a sidecar is a utility container in the pod, and its purpose is t
     ...
     ```
 
-### Create a Redis database
+## Create a Redis database
+
 The Redis database is a service that you can use to persist the data of your app. The Redis database comes with a master and slave modules.
 
 1. Create the Redis controllers and services for both the master and the slave.
@@ -52,36 +56,42 @@ The Redis database is a service that you can use to persist the data of your app
     kubectl create -f redis-slave-service.yaml
     ```
 
-2. Verify that the Redis controllers for the master and the slave are created.
+1. Verify that the Redis controllers for the master and the slave are created.
 
     ```shell
     kubectl get deployment
     ```
+
     Output:
+
     ```shell
     NAME           READY   UP-TO-DATE   AVAILABLE   AGE
     redis-master   1/1     1            1           2m16s
     redis-slave    2/2     2            2           2m15s
     ```
 
-3. Verify that the Redis services for the master and the slave are created.
+1. Verify that the Redis services for the master and the slave are created.
 
     ```shell
     kubectl get svc
     ```
+
     Output:
+
     ```shell
     NAME           TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)        AGE
     redis-master   ClusterIP      172.21.85.39    <none>          6379/TCP       5d
     redis-slave    ClusterIP      172.21.205.35   <none>          6379/TCP       5d
     ```
 
-4. Verify that the Redis pods for the master and the slave are up and running.
+1. Verify that the Redis pods for the master and the slave are up and running.
 
     ```shell
     kubectl get pods
     ```
+
     Output:
+
     ```shell
     NAME                            READY     STATUS    RESTARTS   AGE
     redis-master-4sswq              2/2       Running   0          5d
@@ -98,32 +108,36 @@ The Redis database is a service that you can use to persist the data of your app
     kubectl apply -f guestbook-deployment.yaml
     ```
 
-These commands deploy the Guestbook app on to the Kubernetes cluster. Since we enabled automation sidecar injection, these pods will be also include an Envoy sidecar as they are started in the cluster. Here we have two versions of deployments, a new version (`v2`) in the current directory, and a previous version (`v1`) in a sibling directory. They will be used in future sections to showcase the Istio traffic routing capabilities.
+    These commands deploy the Guestbook app on to the Kubernetes cluster. Since we enabled automation sidecar injection, these pods will be also include an Envoy sidecar as they are started in the cluster. Here we have two versions of deployments, a new version (`v2`) in the current directory, and a previous version (`v1`) in a sibling directory. They will be used in future sections to showcase the Istio traffic routing capabilities.
 
-2. Create the guestbook service.
+1. Create the guestbook service.
 
     ```shell
     kubectl create -f guestbook-service.yaml
     ```
 
-3. Verify that the service was created.
+1. Verify that the service was created.
 
     ```shell
     kubectl get svc
     ```
+
     Output:
+
     ```shell
     NAME           TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)        AGE
     guestbook      LoadBalancer   172.21.36.181   169.61.37.140   80:32149/TCP   5d
     ...
     ```
 
-4. Verify that the pods are up and running.
+1. Verify that the pods are up and running.
 
     ```shell
     kubectl get pods
     ```
+
     Sample output:
+
     ```shell
     NAME                            READY   STATUS    RESTARTS   AGE
     guestbook-v1-98dd9c654-dz8dq    2/2     Running   0          30s
@@ -139,7 +153,8 @@ These commands deploy the Guestbook app on to the Kubernetes cluster. Since we e
 
     Note that each guestbook pod has 2 containers in it. One is the guestbook container, and the other is the Envoy proxy sidecar.
 
-### Use Watson Tone Analyzer
+## Use Watson Tone Analyzer
+
 Watson Tone Analyzer detects the tone from the words that users enter into the Guestbook app. The tone is converted to the corresponding emoticons.
 
 1. Create Watson Tone Analyzer in your account.
@@ -148,21 +163,21 @@ Watson Tone Analyzer detects the tone from the words that users enter into the G
     ibmcloud resource service-instance-create my-tone-analyzer-service tone-analyzer lite us-south
     ```
 
-2. Create the service key for the Tone Analyzer service. This command should output the credentials you just created. You will need the value for **apikey** & **url** later.
+1. Create the service key for the Tone Analyzer service. This command should output the credentials you just created. You will need the value for **apikey** & **url** later.
 
     ```shell
     ibmcloud resource service-key-create tone-analyzer-key Manager --instance-name my-tone-analyzer-service
     ```
 
-3. If you need to get the service-keys later, you can use the following command:
+1. If you need to get the service-keys later, you can use the following command:
 
     ```shell
     ibmcloud resource service-key tone-analyzer-key
     ```
 
-4. Open the `analyzer-deployment.yaml` and find the env section near the end of the file. Replace `YOUR_API_KEY` with your own API key, and replace `YOUR_URL` with the url value you saved before. YOUR_URL should look something like `https://gateway.watsonplatform.net/tone-analyzer/api`. Save the file.
+1. Open the `analyzer-deployment.yaml` and find the env section near the end of the file. Replace `YOUR_API_KEY` with your own API key, and replace `YOUR_URL` with the url value you saved before. YOUR_URL should look something like `https://gateway.watsonplatform.net/tone-analyzer/api`. Save the file.
 
-5. Deploy the analyzer pods and service, using the `analyzer-deployment.yaml` and `analyzer-service.yaml` files found in the `guestbook/v2` directory. The analyzer service talks to Watson Tone Analyzer to help analyze the tone of a message.
+1. Deploy the analyzer pods and service, using the `analyzer-deployment.yaml` and `analyzer-service.yaml` files found in the `guestbook/v2` directory. The analyzer service talks to Watson Tone Analyzer to help analyze the tone of a message.
 
     ```shell
     kubectl apply -f analyzer-deployment.yaml
@@ -171,4 +186,4 @@ Watson Tone Analyzer detects the tone from the words that users enter into the G
 
 Great! Your guestbook app is up and running. In Exercise 4, you'll be able to see the app in action by directly accessing the service endpoint. You'll also be able to view Telemetry data for the app.
 
-#### [Continue to Exercise 4 - Telemetry](../exercise-4/README.md)
+## [Continue to Exercise 4 - Telemetry](../exercise-4/README.md)

--- a/workshop/exercise-4/README.md
+++ b/workshop/exercise-4/README.md
@@ -1,10 +1,10 @@
 # Exercise 4 - Observe service telemetry: metrics and tracing
 
-### Challenges with microservices
+## Challenges with microservices
 
 We all know that microservice architecture is the perfect fit for cloud native applications and it increases the delivery velocities greatly. Envision you have many microservices that are delivered by multiple teams, how do you observe the the overall platform and each of the service to find out exactly what is going on with each of the services?  When something goes wrong, how do you know which service or which communication among the few services are causing the problem?
 
-### Istio telemetry
+## Istio telemetry
 
 Istio's tracing and metrics features are designed to provide broad and granular insight into the health of all services. Istio's role as a service mesh makes it the ideal data source for observability information, particularly in a microservices environment. As requests pass through multiple services, identifying performance bottlenecks becomes increasingly difficult using traditional debugging techniques. Distributed tracing provides a holistic view of requests transiting through multiple services, allowing for immediate identification of latency issues. With Istio, distributed tracing comes by default. This will expose latency, retry, and failure information for each hop in a request.
 
@@ -19,7 +19,7 @@ You can read more about how [Istio mixer enables telemetry reporting](https://is
     kubectl get services -n istio-system
     ```
 
-3. Obtain the guestbook endpoint to access the guestbook.
+1. Obtain the guestbook endpoint to access the guestbook.
 
     You can access the guestbook via the external IP for your service as guestbook is deployed as a load balancer service. Get the EXTERNAL-IP of the guestbook service via output below:
 
@@ -29,7 +29,7 @@ You can read more about how [Istio mixer enables telemetry reporting](https://is
 
     Go to this EXTERNAL-IP address in the browser to try out your guestbook. This service will route you to either v1 or v2, at random. If you wish to see a different version, you'll need to do a hard refresh (`cmd + shift + r` on a mac, or `ctrl + f5` on a PC).
 
-![](../README_images/guestbook1.png)
+![Guestbook app screenshot](../README_images/guestbook1.png)
 
 1. Generate a small load to the app, replacing guestbook_IP with the EXTERNAL-IP.
 
@@ -39,61 +39,65 @@ You can read more about how [Istio mixer enables telemetry reporting](https://is
 
 ## View guestbook telemetry data
 
-#### Jaeger
+### Jaeger
 
 1. Launch the Jaeger dashboard:
 
     ```shell
     istioctl dashboard jaeger
     ```
-2. From the **Services** menu, select either the **guestbook** or **analyzer** service.
-3. Scroll to the bottom and click on **Find Traces** button to see traces.
-4. Use Ctrl-C in the terminal to exit the port-foward when you are done.
+
+1. From the **Services** menu, select either the **guestbook** or **analyzer** service.
+1. Scroll to the bottom and click on **Find Traces** button to see traces.
+1. Use Ctrl-C in the terminal to exit the port-foward when you are done.
 
 Read more about [Jaeger](https://www.jaegertracing.io/docs/)
 
-#### Grafana
+### Grafana
 
 1. Establish port forwarding from local port 3000 to the Grafana instance:
 
     ```shell
     istioctl dashboard grafana
     ```
-![](../README_images/grafana.png)
 
-2. Navigate to the `Istio Service Dashboard` by clicking on the Home menu on the top left, then Istio, then Istio Service Dashboard.
+![Grafana dashboard](../README_images/grafana.png)
 
-3. Select guestbook in the Service drop down.
+1. Navigate to the `Istio Service Dashboard` by clicking on the Home menu on the top left, then Istio, then Istio Service Dashboard.
 
-4. In a different tab, visit the guestbook application and refresh the page multiple times to generate some load, or run the load script you used previously. Switch back to the Grafana tab.
-   
-5. Use Ctrl-C in the terminal to exit the port-foward when you are done.
+1. Select guestbook in the Service drop down.
 
-This Grafana dashboard provides metrics for each workload. Explore the other dashboard provided as well. 
+1. In a different tab, visit the guestbook application and refresh the page multiple times to generate some load, or run the load script you used previously. Switch back to the Grafana tab.
+
+1. Use Ctrl-C in the terminal to exit the port-foward when you are done.
+
+This Grafana dashboard provides metrics for each workload. Explore the other dashboard provided as well.
 
 Read more about [Grafana](http://docs.grafana.org/).
 
-#### Prometheus
+### Prometheus
 
 1. Establish port forwarding from local port 9090 to the Prometheus instance.
 
     ```shell
     istioctl dashboard prometheus
     ```
-![](../README_images/prometheus.jpg)
 
-2. In the “Expression” input box, enter: `istio_request_bytes_count`. Click Execute and then select Graph.
+![Prometheus dashboard](../README_images/prometheus.jpg)
 
-3. Then try another query: `istio_requests_total{destination_service="guestbook.default.svc.cluster.local", destination_version="2.0"}`
+1. In the “Expression” input box, enter: `istio_request_bytes_count`. Click Execute and then select Graph.
 
-4. Use Ctrl-C in the terminal to exit the port-foward when you are done.
+1. Then try another query: `istio_requests_total{destination_service="guestbook.default.svc.cluster.local", destination_version="2.0"}`
 
-#### Kiali
+1. Use Ctrl-C in the terminal to exit the port-foward when you are done.
+
+### Kiali
 
 Kiali is an open-source project that installs on top of Istio to visualize your service mesh. It provides deeper insight into how your microservices interact with one another, and provides features such as circuit breakers and request rates for your services
 
 1. Create a secret which will be used to set the login credentials for Kiali
-```
+
+```shell
 cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: Secret
@@ -108,24 +112,25 @@ data:
   passphrase: "YWRtaW4="
 EOF
 ```
-2. Establish port forwarding from local port 20001 to the Kiali instance.
+
+1. Establish port forwarding from local port 20001 to the Kiali instance.
 
     ```shell
     istioctl dashboard kiali
     ```
-![](../README_images/kiali.png) 
 
-3. Login with `admin` for both username and password.
-4. Select Graph and then choose `default` namespace. You should see a visual service graph of the various services in your Istio mesh.
-5. Use the `Edge Labels` dropdown and select `Traffic rate per second` to see the request rates as well.
-6. Kiali has a number of views to help you visualize your services. Click through the vairous tabs to explore the service graph, and the various views for workloads, applications, and services.
+![Kiali dashboard](../README_images/kiali.png)
+
+1. Login with `admin` for both username and password.
+1. Select Graph and then choose `default` namespace. You should see a visual service graph of the various services in your Istio mesh.
+1. Use the `Edge Labels` dropdown and select `Traffic rate per second` to see the request rates as well.
+1. Kiali has a number of views to help you visualize your services. Click through the vairous tabs to explore the service graph, and the various views for workloads, applications, and services.
 
 ## Understand what happened
 
 Although Istio proxies are able to automatically send spans, they need some hints to tie together the entire trace. Apps need to propagate the appropriate HTTP headers so that when the proxies send span information to Zipkin or Jaeger, the spans can be correlated correctly into a single trace.
 
 In the example, when a user visits the Guestbook app, the HTTP request is sent from the guestbook service to Watson Tone Analyzer. In order for the individual spans of guestbook service and Watson Tone Analyzer to be tied together, we have modified the guestbook service to extract the required headers (x-request-id, x-b3-traceid, x-b3-spanid, x-b3-parentspanid, x-b3-sampled, x-b3-flags, x-ot-span-context) and forward them onto the analyzer service when calling the analyzer service from the guestbook service. The change is in the `v2/guestbook/main.go`. By using the `getForwardHeaders()` method, we are able to extract the required headers, and then we use the required headers further when calling the analyzer service via the `getPrimaryTone()` method.
-
 
 ## Questions
 
@@ -135,4 +140,4 @@ In the example, when a user visits the Guestbook app, the HTTP request is sent f
 
 3. What distributed tracing system does Istio support by default?  A: 1. Zipkin 2. Kibana 3. LogStash 4. Jaeger. (1 and 4 are correct)
 
-#### [Continue to Exercise 5 - Expose the service mesh with the Istio Ingress Gateway](../exercise-5/README.md)
+## [Continue to Exercise 5 - Expose the service mesh with the Istio Ingress Gateway](../exercise-5/README.md)

--- a/workshop/exercise-5/README.md
+++ b/workshop/exercise-5/README.md
@@ -4,9 +4,9 @@ The components deployed on the service mesh by default are not exposed outside t
 
 An Ingress Gateway resource can be created to allow external requests through the Istio Ingress Gateway to the backing services.
 
-![](../README_images/istio2.jpg)
+![Using istio gateway](../README_images/istio2.jpg)
 
-### Expose the Guestbook app with Ingress Gateway
+## Expose the Guestbook app with Ingress Gateway
 
 1. Configure the guestbook default route with the Istio Ingress Gateway. The `guestbook-gateway.yaml` file is in this repository (istio101) in the `workshop/plans` directory.
 
@@ -15,22 +15,25 @@ cd ../../plans
 kubectl create -f guestbook-gateway.yaml
 ```
 
-2. Get the **EXTERNAL-IP** of the Istio Ingress Gateway.
+1. Get the **EXTERNAL-IP** of the Istio Ingress Gateway.
 
 ```shell
 kubectl get service istio-ingressgateway -n istio-system
 ```
+
 Output:
+
 ```shell
 NAME                   TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)                                       AGE
 istio-ingressgateway   LoadBalancer   172.21.254.53    169.6.1.1       80:31380/TCP,443:31390/TCP,31400:31400/TCP    1m
 2d
 ```
 
-3. Make note of the external IP address that you retrieved in the previous step, as it will be used to access the Guestbook app in later parts of the course. Create an environment variable called $INGRESS_IP with your IP address.
+1. Make note of the external IP address that you retrieved in the previous step, as it will be used to access the Guestbook app in later parts of the course. Create an environment variable called $INGRESS_IP with your IP address.
 
 Example:
-```
+
+```shell
 export INGRESS_IP=169.6.1.1
 ```
 
@@ -40,10 +43,12 @@ NLB host names are the DNS host names you can generate for each IBM Cloud Kubern
 
 You can run the IBM Cloud Kubernetes Service ALB, an API gateway of your choice, an Istio ingress gateway, and an MQTT server in parallel in your IBM Cloud Kubernetes Service cluster. Each one will have its own:
 
-    1. Publicly available wildcard host name
-    2. Wildcard SSL certificate associated with the host name
-    3. Health checks that you can configure if you use multizone deployments. 
-    
+```text
+1. Publicly available wildcard host name
+2. Wildcard SSL certificate associated with the host name
+3. Health checks that you can configure if you use multizone deployments.
+```
+
 Let's leverage this feature with Istio ingress gateway:
 
 1. Let's first check if you have any NLB host names for your cluster:
@@ -51,41 +56,45 @@ Let's leverage this feature with Istio ingress gateway:
     ```shell
     ibmcloud ks nlb-dnss --cluster $MYCLUSTER
     ```
+
    If you haven't used this feature before, you will get an empty list.
 
-2. Obtain the Istio ingress gateway's external IP. Get the EXTERNAL-IP of the istio-ingressgateway service via output below:
+1. Obtain the Istio ingress gateway's external IP. Get the EXTERNAL-IP of the istio-ingressgateway service via output below:
 
     ```shell
     kubectl get service istio-ingressgateway -n istio-system
     ```
-    
-3. Create the NLB host with the Istio ingress gateway's public IP address:
+
+1. Create the NLB host with the Istio ingress gateway's public IP address:
 
     ```shell
     ibmcloud ks nlb-dns-create --cluster $MYCLUSTER --ip $INGRESS_IP
     ```
 
-4. List the NLB host names for your cluster:
+1. List the NLB host names for your cluster:
 
     ```shell
     ibmcloud ks nlb-dnss --cluster $MYCLUSTER
     ```
 
     Example output:
-    ```
+
+    ```shell
    Retrieving host names, certificates, IPs, and health check monitors for network load balancer (NLB) pods in cluster <cluster_name>...
     OK
-    Hostname                                                                             IP(s)               Health Monitor   SSL Cert Status   SSL Cert Secret Name   
-    mycluster-85f044fc29ce613c264409c04a76c95d-0001.us-east.containers.appdomain.cloud   ["169.1.1.1"]   None             created           mycluster-85f044fc29ce613c264409c04a76c95d-0001   
+    Hostname                                                                             IP(s)               Health Monitor   SSL Cert Status   SSL Cert Secret Name
+    mycluster-85f044fc29ce613c264409c04a76c95d-0001.us-east.containers.appdomain.cloud   ["169.1.1.1"]       None             created           mycluster-85f044fc29ce613c264409c04a76c95d-0001
     ```
 
 1. Make note of the NLB host name (<nlb_host_name>), as it will be used to access your Guestbook app in later parts of the course. Create an environment variable for it and test using curl or visit in your browser.
 
     Example:
-    ```
+
+    ```shell
     export NLB_HOSTNAME=mycluster-85f044fc29ce613c264409c04a76c95d-0001.us-east.containers.appdomain.cloud
     ```
-    ```
+
+    ```shell
     curl $NLB_HOSTNAME
     ```
 
@@ -95,27 +104,31 @@ Let's leverage this feature with Istio ingress gateway:
     ibmcloud ks nlb-dns-monitor-configure --cluster $MYCLUSTER --nlb-host $NLB_HOSTNAME --type HTTP --description "Istio ingress gateway health check" --path "/healthz/ready" --port 15020 --enable
     ```
 
-7. Monitor the health check of the NLB host for Istio ingress gateway:
+1. Monitor the health check of the NLB host for Istio ingress gateway:
 
     ```shell
     ibmcloud ks nlb-dns-monitor-status --cluster $MYCLUSTER
     ```
-    
+
     After waiting for a bit, you should start to see the health monitor's status changed to Enabled.
-    
+
     Example output:
-    ```
+
+    ```shell
     Retrieving health check monitor statuses for NLB pods...
     OK
-    Hostname                                                                             IP              Health Monitor   H.Monitor Status   
+    Hostname                                                                             IP          Health Monitor   H.Monitor Status  
     mycluster-85f044fc29ce613c264409c04a76c95d-0001.us-east.containers.appdomain.cloud   169.1.1.1   Enabled          Healthy
     ```
 
 Congratulations! You extended the base Ingress features by providing a DNS entry to the Istio service.
 
-## References:
-[Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/)
-[Istio Ingress](https://istio.io/docs/tasks/traffic-management/ingress.html)
-[Bring your own ALB](https://www.ibm.com/blogs/bluemix/2019/04/bring-your-own-alb-dns-with-health-checks-and-ssl-certificates-beta/)
+## References
 
-#### [Continue to Exercise 6 - Traffic Management](../exercise-6/README.md)
+* [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/)
+
+* [Istio Ingress](https://istio.io/docs/tasks/traffic-management/ingress.html)
+
+* [Bring your own ALB](https://www.ibm.com/blogs/bluemix/2019/04/bring-your-own-alb-dns-with-health-checks-and-ssl-certificates-beta/)
+
+## [Continue to Exercise 6 - Traffic Management](../exercise-6/README.md)

--- a/workshop/exercise-6/README.md
+++ b/workshop/exercise-6/README.md
@@ -1,27 +1,35 @@
 # Exercise 6 - Perform traffic management
 
 ## Using rules to manage traffic
+
 The core component used for traffic management in Istio is Pilot, which manages and configures all the Envoy proxy instances deployed in a particular Istio service mesh. It lets you specify what rules you want to use to route traffic between Envoy proxies, which run as sidecars to each service in the mesh. Each service consists of any number of instances running on pods, containers, VMs etc. Each service can have any number of versions (a.k.a. subsets). There can be distinct subsets of service instances running different variants of the app binary. These variants are not necessarily different API versions. They could be iterative changes to the same service, deployed in different environments (prod, staging, dev, etc.). Pilot translates high-level rules into low-level configurations and distributes this config to Envoy instances. Pilot uses three types of configuration resources to manage traffic within its service mesh: Virtual Services, Destination Rules, and Service Entries.
 
 ### Virtual Services
+
 A [VirtualService](https://istio.io/docs/reference/config/istio.networking.v1alpha3/#VirtualService) defines a set of traffic routing rules to apply when a host is addressed. Each routing rule defines matching criteria for traffic of a specific protocol. If the traffic is matched, then it is sent to a named [destination](https://istio.io/docs/reference/config/istio.networking.v1alpha3.html#Destination) service (or [subset](https://istio.io/docs/reference/config/istio.networking.v1alpha3/#Subset) or version of it) defined in the service registry.
 
 ### Destination Rules
+
 A [DestinationRule](https://istio.io/docs/reference/config/istio.networking.v1alpha3/#Destination) defines policies that apply to traffic intended for a service after routing has occurred. These rules specify configuration for load balancing, connection pool size from the sidecar, and outlier detection settings to detect and evict unhealthy hosts from the load balancing pool. Any destination `host` and `subset` referenced in a `VirtualService` rule must be defined in a corresponding `DestinationRule`.
 
 ### Service Entries
+
 A [ServiceEntry](https://istio.io/docs/reference/config/istio.networking.v1alpha3.html#ServiceEntry) configuration enables services within the mesh to access a service not necessarily managed by Istio. The rule describes the endpoints, ports and protocols of a white-listed set of mesh-external domains and IP blocks that services in the mesh are allowed to access.
 
 ## The Guestbook app
+
 In the Guestbook app, there is one service: guestbook. The guestbook service has two distinct versions: the base version (version 1) and the modernized version (version 2). Each version of the service has three instances based on the number of replicas in [guestbook-deployment.yaml](https://github.com/linsun/examples/blob/master/guestbook-go/guestbook-deployment.yaml) and [guestbook-v2-deployment.yaml](https://github.com/linsun/examples/blob/master/guestbook-go/guestbook-v2-deployment.yaml). By default, prior to creating any rules, Istio will route requests equally across version 1 and version 2 of the guestbook service and their respective instances in a round robin manner. However, new versions of a service can easily introduce bugs to the service mesh, so following A/B Testing and Canary Deployments is good practice.
 
 ### A/B testing with Istio
+
 A/B testing is a method of performing identical tests against two separate service versions in order to determine which performs better. To prevent Istio from performing the default routing behavior between the original and modernized guestbook service, define the following rules (found in [istio101/workshop/plans](https://github.com/IBM/istio101/tree/master/workshop/plans)):
 
 ```shell
 kubectl create -f guestbook-destination.yaml
 ```
+
 Let's examine the rule:
+
 ```yaml
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
@@ -39,10 +47,13 @@ spec:
 ```
 
 Next, apply the VirtualService
+
 ```shell
 kubectl replace -f virtualservice-all-v1.yaml
 ```
+
 Let's examine the rule:
+
 ```yaml
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -64,7 +75,7 @@ The `VirtualService` defines a rule that captures all HTTP traffic coming in thr
 
 View the guestbook application using the `$NLB_HOSTNAME` specified in [Exercise 5](../exercise-5/README.md) and enter it as a URL in Firefox or Chrome web browsers. You can use the echo command to get this value, if you don't remember it.
 
-```
+```shell
 echo $NLB_HOSTNAME
 ```
 
@@ -73,7 +84,9 @@ To enable the Istio service mesh for A/B testing against the new service version
 ```shell
 kubectl replace -f virtualservice-test.yaml
 ```
+
 Let's examine the rule:
+
 ```yaml
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -99,17 +112,20 @@ spec:
             subset: v1
 ```
 
-![](../README_images/firefoxchrome.png)
+![guestbook app in chrome and firefox](../README_images/firefoxchrome.png)
 
 In Istio `VirtualService` rules, there can be only one rule for each service and therefore when defining multiple [HTTPRoute](https://istio.io/docs/reference/config/istio.networking.v1alpha3/#HTTPRoute) blocks, the order in which they are defined in the yaml matters. Hence, the original `VirtualService` rule is modified rather than creating a new rule. With the modified rule, incoming requests originating from `Firefox` browsers will go to the newer version of guestbook. All other requests fall-through to the next block, which routes all traffic to the original version of guestbook.
 
 ### Canary deployment
+
 In `Canary Deployments`, newer versions of services are incrementally rolled out to users to minimize the risk and impact of any bugs introduced by the newer version. To begin incrementally routing traffic to the newer version of the guestbook service, modify the original `VirtualService` rule:
 
 ```shell
 kubectl replace -f virtualservice-80-20.yaml
 ```
+
 Let's examine the rule:
+
 ```yaml
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -160,11 +176,13 @@ EOF
 ```
 
 ### Implementing circuit breakers with destination rules
+
 Istio `DestinationRules` allow users to configure Envoy's implementation of [circuit breakers](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/circuit_breaking). Circuit breakers are critical for defining the behavior for service-to-service communication in the service mesh. In the event of a failure for a particular service, circuit breakers allow users to set global defaults for failure recovery on a per service and/or per service version basis. Users can apply a [traffic policy](https://istio.io/docs/reference/config/istio.networking.v1alpha3.html#TrafficPolicy) at the top level of the `DestinationRule` to create circuit breaker settings for an entire service, or it can be defined at the subset level to create settings for a particular version of a service.
 
 Depending on whether a service handles [HTTP](https://istio.io/docs/reference/config/istio.networking.v1alpha3/#ConnectionPoolSettings.HTTPSettings) requests or [TCP](https://istio.io/docs/reference/config/istio.networking.v1alpha3/#ConnectionPoolSettings.TCPSettings) connections, `DestinationRules` expose a number of ways for Envoy to limit traffic to a particular service as well as define failure recovery behavior for services initiating the connection to an unhealthy service.
 
 ## Further reading
+
 * [Istio Concept](https://istio.io/docs/concepts/traffic-management/)
 * [Istio Rules API](https://istio.io/docs/reference/config/istio.networking.v1alpha3)
 * [Istio V1alpha1 to V1alpha3 Converter Tool](https://istio.io/docs/reference/commands/istioctl.html#istioctl%20experimental%20convert-networking-config)
@@ -173,12 +191,11 @@ Depending on whether a service handles [HTTP](https://istio.io/docs/reference/co
 * [Circuit Breaking](https://blog.openshift.com/microservices-patterns-envoy-part-i/)
 * [Timeouts and Retries](https://blog.openshift.com/microservices-patterns-envoy-proxy-part-ii-timeouts-retries/)
 
-
-
 ## Questions
+
 1. Where are routing rules defined?  Options: (VirtualService, DestinationRule, ServiceEntry)  Answer: VirtualService
 1. Where are service versions (subsets) defined?  Options: (VirtualService, DestinationRule, ServiceEntry)  Answer: DestinationRule
 1. Which Istio component is responsible for sending traffic management configurations to Istio sidecars?  Options: (Mixer, Citadel, Pilot, Kubernetes)  Answer: Pilot
 1. What is the name of the default proxy that runs in Istio sidecars and routes requests within the service mesh?  Options: (NGINX, Envoy, HAProxy)  Answer: Envoy
 
-#### [Continue to Exercise 7 - Security](../exercise-7/README.md)
+## [Continue to Exercise 7 - Security](../exercise-7/README.md)

--- a/workshop/exercise-7/README.md
+++ b/workshop/exercise-7/README.md
@@ -42,7 +42,7 @@ When Envoy proxies establish a connection, they exchange and validate certificat
     istio-citadel   1         1         1            1           15h
     ```
 
-2. Define mTLS Authentication Policy
+1. Define mTLS Authentication Policy
 
    First, we create a `MeshPolicy` for configuring the receiving end to use mTLS. The following two destination rules will then configure the client side to use mTLS. We'll update the previously created DestinationRule to include mTLS and create a new blanket rule (`*.local`) for all other services. Run the following command to enable mTLS across your cluster:
 
@@ -84,9 +84,9 @@ spec:
       mode: ISTIO_MUTUAL
 EOF
 ```
-   
+
    You should see:
-    
+
    ```shell
     meshpolicy.authentication.istio.io/default created
     destinationrule.networking.istio.io/destination created
@@ -94,26 +94,26 @@ EOF
    ```
 
    Confirm the policy for the receiving services to use mTLS has been created:
-    
+
    ```shell
    kubectl get meshpolicies
    ```
-   
+
    Output:
-   
+
    ```shell
    NAME              AGE
    default           1m
    ```
 
    Confirm the destination rules for client-side mTLS has been created:
-     
+
    ```shell
    kubectl get destinationrules
    ```
-   
+
    Output:
-    
+
    ```shell
    NAME                         HOST        AGE
    destination                  *.local     3m21s
@@ -122,7 +122,7 @@ EOF
 
 ## Verifying the Authenticated Connection
 
-If mTLS is working correctly, the Guestbook app should continue to operate as expected, without any user visible impact. Istio will automatically add (and manage) the required certificates and private keys. 
+If mTLS is working correctly, the Guestbook app should continue to operate as expected, without any user visible impact. Istio will automatically add (and manage) the required certificates and private keys.
 
 To verify this, you can use an experimental `istioctl` feature to describe pods.
 
@@ -150,13 +150,13 @@ Output:
     kubectl get pods
     ```
 
-2. Copy the name of the guestbook v2 pod, for exmaple: `guestbook-v2-f9f597d8d-zbhkt`.
+1. Copy the name of the guestbook v2 pod, for exmaple: `guestbook-v2-f9f597d8d-zbhkt`.
 
     ```shell
     istioctl x describe pod guestbook-v2-f9f597d8d-zbhkt
     ```
 
-3. You should see something like this:
+1. You should see something like this:
 
     ```shell
     Pod: guestbook-v2-f9f597d8d-zbhkt
@@ -188,29 +188,31 @@ Istio support Role Based Access Control(RBAC) for HTTP services in the service m
     kubectl create sa analyzer
     ```
 
-2. Modify guestbook and analyzer deployments to use leverage the service accounts.
+1. Modify guestbook and analyzer deployments to use leverage the service accounts.
 
-* Navigate to your guestbook dir first, for example:
-```shell
-cd ../guestbook
-```
+    * Navigate to your guestbook dir first, for example:
 
-* Add serviceaccount to your guestbook and analyzer deployments
+    ```shell
+    cd ../guestbook
+    ```
 
-  ```shell
-  echo "      serviceAccountName: guestbook" >> v1/guestbook-deployment.yaml
-  echo "      serviceAccountName: guestbook" >> v2/guestbook-deployment.yaml
-  echo "      serviceAccountName: analyzer" >> v2/analyzer-deployment.yaml
-  ```
+    * Add serviceaccount to your guestbook and analyzer deployments
 
-* redeploy the guestbook and analyzer deployments
-  ```shell
-  kubectl replace -f v1/guestbook-deployment.yaml
-  kubectl replace -f v2/guestbook-deployment.yaml
-  kubectl replace -f v2/analyzer-deployment.yaml
-  ```
+    ```shell
+    echo "      serviceAccountName: guestbook" >> v1/guestbook-deployment.yaml
+    echo "      serviceAccountName: guestbook" >> v2/guestbook-deployment.yaml
+    echo "      serviceAccountName: analyzer" >> v2/analyzer-deployment.yaml
+    ```
 
-3. Create a `AuthorizationPolicy` to disable all access to analyzer service.  This will effectively not allow guestbook or any services to access it.
+    * redeploy the guestbook and analyzer deployments
+
+    ```shell
+    kubectl replace -f v1/guestbook-deployment.yaml
+    kubectl replace -f v2/guestbook-deployment.yaml
+    kubectl replace -f v2/analyzer-deployment.yaml
+    ```
+
+1. Create a `AuthorizationPolicy` to disable all access to analyzer service.  This will effectively not allow guestbook or any services to access it.
 
 ```shell
 cat <<EOF | kubectl create -f -
@@ -230,12 +232,12 @@ Output:
 ```shell
 authorizationpolicy.security.istio.io/analyzeraccess created
 ```
-    
-4.  Visit the Guestbook app from your favorite browser and validate that Guestbook V1 continues to work while Guestbook V2 will not run correctly. For every new message you write on the Guestbook v2 app, you will get a message such as "Error - unable to detect Tone from the Analyzer service".  It can take up to 15 seconds for the change to propogate to the envoy sidecar(s) so you may not see the error right away.
+
+4. Visit the Guestbook app from your favorite browser and validate that Guestbook V1 continues to work while Guestbook V2 will not run correctly. For every new message you write on the Guestbook v2 app, you will get a message such as "Error - unable to detect Tone from the Analyzer service".  It can take up to 15 seconds for the change to propogate to the envoy sidecar(s) so you may not see the error right away.
 
 5. Configure the Analyzer service to only allow access from the Guestbook service using the added `rules` section:
 
-```
+```shell
 cat <<EOF | kubectl apply -f -
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
@@ -255,7 +257,7 @@ spec:
 EOF
 ```
 
-6.  Visit the Guestbook app from your favorite browser and validate that Guestbook V2 works now.  It can take a few seconds for the change to propogate to the envoy sidecar(s) so you may not observe Guestbook V2 to function right away.
+6. Visit the Guestbook app from your favorite browser and validate that Guestbook V2 works now.  It can take a few seconds for the change to propogate to the envoy sidecar(s) so you may not observe Guestbook V2 to function right away.
 
 ## Cleanup
 


### PR DESCRIPTION
Updates for markdown linting for exercises except for parts of exercise 7.

Exercise 7 has outdented shell here docs inside an ordered list of steps for correct copy/paste function in gitbook. In order for some markdown rendering (github) platforms to correctly keep the list numbering, explicit labels are provided. This does not fix rendering on gitbook, which correctly identifies the outdented sections as breaks to the ordered list.