### PR TITLE
Fixing the broken workshop link in the README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is the repository for the [Istio][istio] 101 workshop from IBM.
 
 - [presentation](./presentation) -- the data for the teacher/leader of the workshop
-- [workshop](./workshop) -- the vanilla code for the code of the workshop
+- [docs](./docs) -- the vanilla code for the participants of the workshop
 
 
 ## License


### PR DESCRIPTION
The workshop link in your README.md was broken, this is just a doc update to fix it if you'd like. I'm going through the content and figured that I could help out!

Fixes #183

**Before**
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/2333708/173669813-9a71b16e-76bf-40cc-b9f8-daa92423c69d.png">

**After**
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/2333708/173670025-8c46cd3e-7d46-40ae-94af-653211320de8.png">
